### PR TITLE
fix: Add link styling to every link which doesn't have one

### DIFF
--- a/src/components/Skeleton.vue
+++ b/src/components/Skeleton.vue
@@ -27,15 +27,15 @@ const props = defineProps({
 
     <footer v-if="!skipFooter">
         <ul>
-            <li><a href="https://github.com/leonarf/VCA4D">Code source sur Github</a></li>
+            <li><a target="_blank" class="hover:underline" href="https://github.com/leonarf/VCA4D">Code source sur Github</a></li>
             <li>
-                <RouterLink to="/admin-import">Import a study</RouterLink>
+                <RouterLink class="hover:underline"to="/admin-import">Import a study</RouterLink>
             </li>
             <li>
-                <a href="https://capacity4dev.europa.eu/projects/value-chain-analysis-for-development-vca4d_en">VCA4D's website project</a>
+                <a target="_blank" class="hover:underline" href="https://capacity4dev.europa.eu/projects/value-chain-analysis-for-development-vca4d_en">VCA4D's website project</a>
             </li>
             <li>
-                <a href="https://lebasic.com/">Website developped by Basic</a>
+                <a target="_blank" class="hover:underline" href="https://lebasic.com/">Website developped by Basic</a>
             </li>
         </ul>
     </footer>

--- a/src/components/StudyOverview.vue
+++ b/src/components/StudyOverview.vue
@@ -37,7 +37,7 @@
         </section>
 
         <PdfSection v-if="studyData.briefReportPdfUrl" :study-brief-url="studyData.briefReportPdfUrl" />
-        <a v-if="studyData.fullReportPdfUrl" :href="studyData.fullReportPdfUrl">Download study full report</a>
+        <a target="_blank" class="text-blue-600" v-if="studyData.fullReportPdfUrl" :href="studyData.fullReportPdfUrl">Download study full report</a>
         <section v-if="studyData && studyData.ecoData">
             <Sankey :studyData="studyData"/>
         </section>

--- a/src/components/import/CheckImportedDataStep.vue
+++ b/src/components/import/CheckImportedDataStep.vue
@@ -5,7 +5,7 @@
   <div>
     <h2>Step 2 : Check that all data is there.</h2>
     <p>Complete the file for missing data, then re-upload the file (back to step 1).</p>
-    <a href="https://github.com/leonarf/VCA4D/tree/main/data/xls" target="_blank"
+    <a class="text-blue-600" href="https://github.com/leonarf/VCA4D/tree/main/data/xls" target="_blank"
       >Here you can find example blank file to help you upload your study</a
     >
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -66,7 +66,7 @@ watch(mandatoryStudiesPart, async (newMandatoryParts, oldMandatoryParts) => {
         </p>
         <p>
           The European Commission has developed the VCA4D standardised methodological framework for
-          analysis (<a href="https://capacity4dev.europa.eu/info/1-vca4d-methodology_en">The VCA4D Methodology | Capacity4dev</a>). It aims at understanding to what extent
+          analysis (<a target="_blank" class="text-blue-600" href="https://capacity4dev.europa.eu/info/1-vca4d-methodology_en">The VCA4D Methodology | Capacity4dev</a>). It aims at understanding to what extent
           the value chain allows for inclusive economic growth and whether it is both socially and
           environmentally sustainable.
         </p>

--- a/src/views/Import.vue
+++ b/src/views/Import.vue
@@ -25,7 +25,7 @@ ol{
                     <div>You have imported this study: <b>{{ studyData['id'] }}</b></div>
                     <div class="ml-4">
                         Press 
-                        <button @click="clearData">Remove</button> or
+                        <a class="cursor-pointer text-blue-600" @click="clearData">Remove</a> or
                     </div>
                 </div>
                 <p v-else>Upload the file to the platform</p>
@@ -111,4 +111,3 @@ onMounted(() => {
     }
 })
 </script>
-  


### PR DESCRIPTION
# Contexte

Agrinatura nous font remarquer ([point 1](https://lebasic-my.sharepoint.com/:w:/r/personal/maxime_lebasic_com/_layouts/15/Doc.aspx?sourcedoc=%7B845CE3C2-1A58-4F2F-928B-F5FCDBE425D8%7D&file=Info.System%20Website%20comments%20HY_FL_avec_commentaire_l%25u00e9onard%20OO.docx&action=default&mobileredirect=true)) que le lien de la description n'a pas le bon style

J'en profite pour update tous les liens qui n'ont à mon avis pas un bon style pour un lien

- Couleur bleue lorsque ce lien est au milieu d'un texte sans lien
- target _blank si le lien est externe (/ telechargement d'un pdf) pour éviter que l'utilisateur quitte la plateforme
- Pas d'underline en hover, sauf dans le footer avec les credits: Sinon les liens en gris ne sont pas assez visible

  <details><summary>screenshot</summary>
  
  ![image](https://github.com/user-attachments/assets/7990f068-7196-494f-ab74-01dc47e1ebdf)
  
  </details>