### PR TITLE
feat: Use pretty names for products as well

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -560,5 +560,99 @@
       "country": "zimbabwe",
       "product": "beef"
     }
+  ],
+  "products": [
+    {
+      "id": "cocoa",
+      "prettyName": "cocoa"
+    },
+    {
+      "id": "coffee",
+      "prettyName": "coffee"
+    },
+    {
+      "id": "cashew",
+      "prettyName": "cashew"
+    },
+    {
+      "id": "banana",
+      "prettyName": "banana"
+    },
+    {
+      "id": "mango",
+      "prettyName": "mango"
+    },
+    {
+      "id": "vanilla",
+      "prettyName": "vanilla"
+    },
+    {
+      "id": "oil palm",
+      "prettyName": "oil palm"
+    },
+    {
+      "id": "beef",
+      "prettyName": "beef"
+    },
+    {
+      "id": "egg",
+      "prettyName": "egg"
+    },
+    {
+      "id": "milk",
+      "prettyName": "milk"
+    },
+    {
+      "id": "cassava",
+      "prettyName": "cassava"
+    },
+    {
+      "id": "cotton",
+      "prettyName": "cotton"
+    },
+    {
+      "id": "groundnut",
+      "prettyName": "groundnut"
+    },
+    {
+      "id": "cowpea",
+      "prettyName": "cowpea"
+    },
+    {
+      "id": "french beans",
+      "prettyName": "french beans"
+    },
+    {
+      "id": "maize",
+      "prettyName": "maize"
+    },
+    {
+      "id": "sorghum",
+      "prettyName": "sorghum"
+    },
+    {
+      "id": "pineapple",
+      "prettyName": "pineapple"
+    },
+    {
+      "id": "freshwater-aquaculture",
+      "prettyName": "freshwater-aquaculture"
+    },
+    {
+      "id": "aquaculture",
+      "prettyName": "aquaculture"
+    },
+    {
+      "id": "coastal fisheries",
+      "prettyName": "coastal fisheries"
+    },
+    {
+      "id": "inland fisheries",
+      "prettyName": "inland fisheries"
+    },
+    {
+      "id": "fisheries",
+      "prettyName": "fisheries"
+    }
   ]
 }

--- a/data/data.json
+++ b/data/data.json
@@ -2,7 +2,7 @@
   "categories": [
     {
       "id": "orchard",
-      "prettyName": "Orchards",
+      "prettyName": "Tree crops",
       "color": "#5F8A64",
       "textColor": "#5F8A64",
       "commodities": [
@@ -44,7 +44,7 @@
     },
     {
       "id": "halieutic",
-      "prettyName": "Halieutic",
+      "prettyName": "Fisheries and aquaculture",
       "color": "#0073CF",
       "textColor": "#0073CF",
       "commodities": [
@@ -588,7 +588,7 @@
     },
     {
       "id": "oil palm",
-      "prettyName": "oil palm"
+      "prettyName": "Palm Oil"
     },
     {
       "id": "beef",
@@ -620,7 +620,7 @@
     },
     {
       "id": "french beans",
-      "prettyName": "french beans"
+      "prettyName": "green beans"
     },
     {
       "id": "maize",

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -1,13 +1,13 @@
 <template>
     <tr>
         <td></td>
-        <td v-for="(study) in studies" :key="`${study.id}`">
+        <td v-for="(study) in studiesWithDetails" :key="`${study.id}`">
             <div class="flex flex-col items-center gap-y-2"
             >
                 <div v-if="study.id" class="flex flex-row items-center justify-center">
-                    <CardFooter :text="getStudyDetails(study).country_name">
+                    <CardFooter :text="study.country_name">
                         <template v-slot:logo>
-                            <LogoCountrySmall :iso-code="getStudyDetails(study)['country_iso_code'] || 'gr'" />
+                            <LogoCountrySmall :iso-code="study['country_iso_code'] || 'gr'" />
                         </template>
                     </CardFooter>
                 </div>
@@ -15,9 +15,9 @@
                     :link="getLink(study, 'LOCAL')"
                     :is-local="false"
                     :is-open="false"
-                    :title="getProduct(study)">
+                    :title="study.product.prettyName">
                     <template v-slot:logo>
-                        <LogoProductLarge :product-name="getProduct(study)"/>
+                        <LogoProductLarge :product-name="study.product.id"/>
                     </template>
                 </Card>
             </div>
@@ -27,8 +27,9 @@
 
 <script setup>
 
+import { computed } from 'vue';
 import { slugify } from '@utils/format.js'
-import { getCountry } from '@utils/data.js'
+import { getCountry, getProduct } from '@utils/data.js'
 import { getLink } from '@utils/router'
 import LogoCountrySmall from '@components/home/LogoCountrySmall.vue';
 import LogoProductLarge from '@components/home/LogoProductLarge.vue';
@@ -38,18 +39,19 @@ const props = defineProps({
     studies: Array,
 })
 
-const getProduct = (study) => {
-    return study?.commodity?.toLowerCase()
-}
+const studiesWithDetails = computed(() => {
+    return props.studies.map(getStudyDetails);
+})
 
 const getStudyDetails = (study) => {
-    var country_iso_code = getCountry(slugify(study?.country))?.iso
-    if (!country_iso_code) {
-        country_iso_code = 'gr'
-    }
+    const country_iso_code = getCountry(slugify(study?.country))?.iso || "gr";
+    const productKey = study?.commodity?.toLowerCase();
+
     return {
+        ...study,
         country_name : getCountry(slugify(study?.country))?.prettyName,
-        country_iso_code: country_iso_code
+        country_iso_code: country_iso_code,
+        product: getProduct(productKey)
     }
 }
 

--- a/src/components/home/ByCategory.vue
+++ b/src/components/home/ByCategory.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { getLink, getCompareProductLink } from '@utils/router'
+import { getCountry, getProduct } from '@utils/data.js'
 import LogoCountrySmall from './LogoCountrySmall.vue';
 import LogoCountryLarge from './LogoCountryLarge.vue';
 import LogoProductLarge from './LogoProductLarge.vue';
@@ -38,7 +39,6 @@ const getStudiesByProduct = () => {
     }))
 }
 
-const getCountry = countryId => props.countries.find(country => country.id === countryId)
 
 
 </script>
@@ -52,13 +52,13 @@ const getCountry = countryId => props.countries.find(country => country.id === c
                         <Card
                             :link="getLink(item.studies[0], currency)"
                             :is-local="item.studies[0].local"
-                            :title="item.product">
+                            :title="getProduct(item.product).prettyName">
                             <template v-slot:logo>
                                 <LogoProductLarge :product-name="item.product"
                                         :alt="`Link to ${item.studies[0].title} study`" />
                             </template>
                             <template v-slot:footer>
-                                <CardFooter :text="getCountry(item.studies[0].country)['prettyName']">
+                                <CardFooter :text="getCountry(item.studies[0].country).prettyName">
                                     <template v-slot:logo>
                                         <LogoCountrySmall :iso-code="getCountry(item.studies[0].country)?.iso || 'gr'" />
                                     </template>
@@ -71,7 +71,7 @@ const getCountry = countryId => props.countries.find(country => country.id === c
                             @click.stop="openedProduct === item.product ? openedProduct = null : openedProduct = item.product"
                             :is-local="false"
                             :is-open="openedProduct === item.product"
-                            :title="item.product"
+                            :title="getProduct(item.product).prettyName"
                             >
                             <template v-slot:logo>
                                 <LogoProductLarge :product-name="item.product" />

--- a/src/components/home/ByContinent.vue
+++ b/src/components/home/ByContinent.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { getLink, getCompareCountryLink } from '@utils/router'
+import { getCountry, getProduct } from '@utils/data.js'
 import LogoProductLarge from './LogoProductLarge.vue';
 import LogoProductSmall from './LogoProductSmall.vue';
 import LogoCountryLarge from './LogoCountryLarge.vue';
@@ -52,10 +53,6 @@ const getStudiesByCountry = () => {
     }))
 }
 
-const getCountry = (countryId) => {
-    return props.countries.find(country => country.id === countryId)
-}
-
 </script>
 
 <template>
@@ -71,7 +68,7 @@ const getCountry = (countryId) => {
                             <LogoCountryLarge :isoCode="getCountry(item.country).iso || 'gr'" />
                         </template>
                         <template v-slot:footer>
-                            <CardFooter :text="item.studies[0].title">
+                            <CardFooter :text="getProduct(item.studies[0].product).prettyName">
                                 <template v-slot:logo>
                                     <LogoProductSmall :product-name="item.studies[0].product" :alt="`Link to ${item.studies[0].title} study`"/>
                                 </template>
@@ -96,7 +93,7 @@ const getCountry = (countryId) => {
                             <Card v-for="study in item.studies" :key="study.id"
                                 :link="getLink(study, currency)"
                                 :is-local="study.local"
-                                :title="study.title">
+                                :title="getProduct(study.product).prettyName">
                                 <template v-slot:logo>
                                     <LogoProductLarge :product-name="study.product" :alt="`Link to ${study.title} study`" />
                                 </template>

--- a/src/components/import/CheckImportedDataStep.vue
+++ b/src/components/import/CheckImportedDataStep.vue
@@ -132,7 +132,7 @@ import { slugify } from '@utils/format.js'
 
 import { ACV_SHEET_NAMES } from '@utils/import/environment.js'
 import { getImportErrors } from '@utils/import/generic.js'
-import { ECO_SHEET_NAMES, getErrors } from '@utils/import/eco.js'
+import { ECO_SHEET_NAMES, HOME_LABELS, getErrors } from '@utils/import/eco.js'
 
 const props = defineProps({
   studyData: Object

--- a/src/components/import/SaveOnGithubStep.vue
+++ b/src/components/import/SaveOnGithubStep.vue
@@ -97,6 +97,7 @@ function sortFunctionByProperties(propertyKeys) {
           return 1
       }
     }
+    return 0;
   }
 }
 

--- a/src/components/import/SaveOnGithubStep.vue
+++ b/src/components/import/SaveOnGithubStep.vue
@@ -63,20 +63,8 @@ const dataFile = computed(() => {
             product: props.studyData.commodity.toLowerCase()
         })
     }
-    jsonData.studies.sort(function (itemA, itemB) {
-        if (itemA.country < itemB.country) {
-            return -1
-        }
-        else if (itemA.country > itemB.country) {
-            return 1
-        }
-        if (itemA.product < itemB.product) {
-            return -1
-        }
-        else if (itemA.product > itemB.product) {
-            return 1
-        }
-    });
+    jsonData.studies.sort(sortFunctionByProperties(["country", "product"]));
+  
     const slugifiedCountry = slugify(props.studyData.country)
     if (!jsonData.countries.find(country => country.id === slugifiedCountry)) {
         jsonData.countries.push({
@@ -84,14 +72,8 @@ const dataFile = computed(() => {
             prettyName: props.studyData.country
         })
     }
-    jsonData.countries.sort(function (itemA, itemB) {
-        if (itemA.id < itemB.id) {
-            return -1
-        }
-        else if (itemA.id > itemB.id) {
-            return 1
-        }
-    });
+    jsonData.countries.sort(sortFunctionByProperties(["id"]));
+
     const existingCommodities = jsonData.categories.reduce((arr, current) => arr.concat(current.commodities), [])
     const slugifiedCommodity = slugify(props.studyData.commodity)
     if (!existingCommodities.includes(slugifiedCommodity)) {
@@ -102,6 +84,19 @@ const dataFile = computed(() => {
         jsonData
         , null, 2)
 })
+
+function sortFunctionByProperties(propertyKeys) {
+  return function(itemA, itemB) {
+    for (var key of propertyKeys) {
+      if (itemA[key] < itemB[key]) {
+          return -1
+      }
+      else if (itemA[key] > itemB[key]) {
+          return 1
+      }
+    }
+  }
+}
 
 const downloadFile = (data, fileName) => {
   const blob = new Blob([data], { type: 'application/json' })

--- a/src/components/import/SaveOnGithubStep.vue
+++ b/src/components/import/SaveOnGithubStep.vue
@@ -80,6 +80,8 @@ const dataFile = computed(() => {
         jsonData.categories.find(category => category.id === 'unknown').commodities.push(slugifiedCommodity)
     }
 
+    jsonData.products = updateProductList(jsonData.products, existingCommodities);
+
     return JSON.stringify(
         jsonData
         , null, 2)
@@ -96,6 +98,20 @@ function sortFunctionByProperties(propertyKeys) {
       }
     }
   }
+}
+
+function updateProductList(products = [], existingProductKeys) {
+  const newProducts = [...products];
+  existingProductKeys.forEach(productKey => {
+    if (!products.find(product => product.id === productKey)) {
+      newProducts.push({
+        id: productKey,
+        prettyName: productKey 
+      });
+    }
+  });
+  newProducts.sort(sortFunctionByProperties("id"));
+  return newProducts;
 }
 
 const downloadFile = (data, fileName) => {

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="text-xl rounded bg-[#dcefbb] flex flex-row flex-wrap gap-y-4 py-3 pl-8 rounded-none md:rounded-full justify-center md:justify-start">
         <div class="bloc">
-            <div class="title">{{ studyData.commodity }}</div>
+            <div class="title">{{ commodityName }}</div>
             <div class="subtitle">Commodity</div>
         </div>
         <div class="bloc">
@@ -22,7 +22,7 @@
 <script setup>
 import { computed } from 'vue'
 import { getCurrencySymbol } from '@utils/currency.js'
-import { getCountry } from '@utils/data.js'
+import { getCountry, getProduct, getStudy } from '@utils/data.js'
 
 const props = defineProps({
     studyData: {
@@ -30,6 +30,10 @@ const props = defineProps({
       required: true,
     }
 })
+
+const commodityName = computed(() => {
+    return getProduct(getStudy(props.studyData.id).product).prettyName;
+});
 
 let dataToDisplay = computed(() => {
     let result = {}
@@ -46,7 +50,7 @@ let dataToDisplay = computed(() => {
 
 <style scoped lang="scss">
     .subtitle {
-        @apply text-[#656565] text-xs
+        @apply text-[#656565] text-xs;
     }
     .title {
         @apply text-[#303030] text-3xl font-thin;

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -121,3 +121,13 @@ export const getAllKnownProducts = () => {
 }
 
 export const getCountry = (countryId) => getCountries().find(country => country.id === countryId)
+
+export function getProduct(productId) {
+    const jsonProducts = jsonData.products;
+    return jsonProducts.find(product => product.id === productId);
+}
+
+export function getStudy(studyId) {
+    const jsonStudies = jsonData.studies;
+    return jsonStudies.find(study => study.id === studyId);
+}


### PR DESCRIPTION
# Context

Certains produits / comodités affichées doivent etre corrigées

- En ajoutant des noms custom (eg. Oil Palm devient Palm Oil)
- En se basant sur le nom de la commodité plutot que le nom de l'étude

<details><summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/087aee81-d79a-47aa-9a7c-f94b34ef849c)

</details>

# Modifications

- Ajout d'un array `products` dans data.json afin de configurer des nomùs custom sans changer les data des études
- Affichage de ces noms partout
  - Dans la home
  - Dans le dashboard de comparaison
  - Dans les header des pages d'études