### PR TITLE
feat: Tweak inclusiveness page

### DIFF
--- a/src/components/StudyInclusiveness.vue
+++ b/src/components/StudyInclusiveness.vue
@@ -20,18 +20,7 @@
             </RouterLink>
         </p>
 
-        <h3 class="mt-8">How is <strong>employment</strong> distributed across the value chain?</h3>
-
-        <p>Methodology</p>
-        <p>Employment data only relate to full time equivalent jobs for this specific value chain and do not include total
-            employment of each actor. In addition, the informal family workforce at the agricultural production level is not
-            accounted for.</p>
-        <div class="flex flex-col gap-y-4 mt-4">
-            <EmploymentDistributionActors :studyData="studyData"/>
-            <EmploymentDistributionJobs :studyData="studyData"/>
-        </div>
-
-        <h3>How is <strong>income</strong> distributed across actors of the value chain?</h3>
+        <QuestionTitle>How is <strong>income</strong> distributed across actors of the value chain?</QuestionTitle>
         <p>Actors that are in small numbers but receive an important share of the value chain's net operating profit are in
             a stronger position of negociation in front of actore that are more divided.</p>
         <p>NB: The income data only relate to this specific value chain: the data do not include any other income from any
@@ -41,9 +30,19 @@
             <NetOperatingProfit :studyData="studyData" :currency="currency"/>
             <NetOperatingProfitPerActor :studyData="studyData" :currency="currency" />
         </div>
+
+        <QuestionTitle class="mt-8">How is <strong>employment</strong> distributed across the value chain?</QuestionTitle>
+        <p>Employment data only relate to full time equivalent jobs for this specific value chain and do not include total
+            employment of each actor. In addition, the informal family workforce at the agricultural production level is not
+            accounted for.</p>
+        <div class="flex flex-col gap-y-4 mt-4">
+            <EmploymentDistributionActors :studyData="studyData"/>
+            <EmploymentDistributionJobs :studyData="studyData"/>
+        </div>
+
         <br>
 
-        <h3>What is the impact of the <strong>governance system</strong> on the income distribution?</h3>
+        <QuestionTitle>What is the impact of the <strong>governance system</strong> on the income distribution?</QuestionTitle>
         <InfoTitle title="Share of farm gate price in final price" class="mb-4 mt-8" :class="{'TODO': !hasPricesData}" />
         <ShareOfFarmPrice v-if="hasPricesData" :data="pricesData"/>
         <br />
@@ -62,6 +61,7 @@ import NetOperatingProfitPerActor from './study/inclusiveness/NetOperatingProfit
 import InfoTitle from '@typography/InfoTitle.vue'
 import GiniIndex from './study/inclusiveness/GiniIndex.vue'
 import ShareOfFarmPrice from './study/inclusiveness/ShareOfFarmPrice.vue'
+import QuestionTitle from "@components/study/QuestionTitle.vue"
 import { computed } from 'vue'
 import { useCurrencyUtils } from '@utils/format'
 import { LOCAL_STORAGE_ID } from '@utils/data.js'

--- a/src/components/StudyInclusiveness.vue
+++ b/src/components/StudyInclusiveness.vue
@@ -43,11 +43,17 @@
         <br>
 
         <QuestionTitle>What is the impact of the <strong>governance system</strong> on the income distribution?</QuestionTitle>
-        <InfoTitle title="Share of farm gate price in final price" class="mb-4 mt-8" :class="{'TODO': !hasPricesData}" />
-        <ShareOfFarmPrice v-if="hasPricesData" :data="pricesData"/>
+        <InfoTitle title="Share of farm gate price in final price" class="mb-4 mt-8"/>
+        <div>
+            <ShareOfFarmPrice v-if="hasPricesData" :data="pricesData"/>
+            <NoDataBadge v-else/>
+        </div>
         <br />
-        <InfoTitle title="Gini index" class="mb-4 mt-8" :class="{ 'TODO': !studyData.ecoData.macroData?.giniIndex}" />
-        <GiniIndex v-if="studyData.ecoData.macroData?.giniIndex" :value="studyData.ecoData.macroData?.giniIndex"/>
+        <InfoTitle title="Gini index" class="mb-4 mt-8" />
+        <div class="mb-8">
+            <GiniIndex v-if="studyData.ecoData.macroData?.giniIndex" :value="studyData.ecoData.macroData?.giniIndex"/>
+            <NoDataBadge v-else/>
+        </div>
     </article>
 </template>
 
@@ -61,6 +67,7 @@ import NetOperatingProfitPerActor from './study/inclusiveness/NetOperatingProfit
 import InfoTitle from '@typography/InfoTitle.vue'
 import GiniIndex from './study/inclusiveness/GiniIndex.vue'
 import ShareOfFarmPrice from './study/inclusiveness/ShareOfFarmPrice.vue'
+import NoDataBadge from '@components/study/NoDataBadge.vue';
 import QuestionTitle from "@components/study/QuestionTitle.vue"
 import { computed } from 'vue'
 import { useCurrencyUtils } from '@utils/format'

--- a/src/components/StudyInclusiveness.vue
+++ b/src/components/StudyInclusiveness.vue
@@ -1,13 +1,24 @@
 <template>
     <article class="mt-8">
         <SectionTitle>
-            <h1>Is the economic growth <strong>inclusive</strong>?</h1>
+            <h1>Is the VC economic growth <strong>inclusive</strong>?</h1>
         </SectionTitle>
-        <p>A value chain is inclusive in one country not only by the number of jobs created, but also considering these
-            jobs' quality. The way the income is distributed across the value chain from the samll producers to the
-            consumers also tell about the power dynamics and the policies that may be improved for more inclusiveness. For
-            detailed information on the value chain's impact on the most vulnerable groups, like women and youth, please go
-            directly to Social sustainability part (*link).</p>
+        <p>
+            To build an image of the inclusiveness of the value chain, a VCA4D study 
+            highlights how the VC organisation and governance involve the various 
+            stakeholders and how the incomes and employment generated are distributed 
+            among social groups. The value chain specific impact on vulnerable groups 
+            such as subsistence-oriented farmers, smallholders, women, youth, and 
+            marginalised people (landless rural workers, minority communities…) is 
+            closely documented. Please also visit
+            <RouterLink 
+                :to="`/study?id=${studyData.id}&view=social-sustainability&currency=${studyData.targetCurrency}`"
+                :class="{ disabled: !studyData.socialData}"
+                class="text-blue-600"
+            >
+                our page on Social Sustainability
+            </RouterLink>
+        </p>
 
         <h3 class="mt-8">How is <strong>employment</strong> distributed across the value chain?</h3>
 
@@ -43,6 +54,7 @@
 
 <script setup>
 import SectionTitle from '@typography/SectionTitle.vue'
+import { RouterLink } from "vue-router";
 import EmploymentDistributionActors from './study/inclusiveness/EmploymentDistributionActors.vue'
 import EmploymentDistributionJobs from './study/inclusiveness/EmploymentDistributionJobs.vue'
 import NetOperatingProfit from './study/inclusiveness/NetOperatingProfit.vue'
@@ -52,6 +64,8 @@ import GiniIndex from './study/inclusiveness/GiniIndex.vue'
 import ShareOfFarmPrice from './study/inclusiveness/ShareOfFarmPrice.vue'
 import { computed } from 'vue'
 import { useCurrencyUtils } from '@utils/format'
+import { LOCAL_STORAGE_ID } from '@utils/data.js'
+
 
 const props = defineProps({
     studyData: Object,
@@ -65,6 +79,9 @@ const hasPricesData = computed(() => {
         return false
     }
     return props.studyData.ecoData.farmToFinalPricesRatio.length > 0
+})
+const isLocalStudy = computed(() => {
+    return studyId === LOCAL_STORAGE_ID;
 })
 
 

--- a/src/components/study/inclusiveness/EmploymentDistributionActors.vue
+++ b/src/components/study/inclusiveness/EmploymentDistributionActors.vue
@@ -1,23 +1,25 @@
 <template>
-    <InfoTitle title="Number of actors" class="mb-4 mt-8" />
-    <div class="flex flex-col mt-4">
-        <div class="flex flex-row flex-wrap items-center justify-center">
-            <div class="w-1/2 md:w-1/5">
-                <NiceMetric label="Number of actors" :value="totalNumberOfActors" />
-            </div>
-            <div class="w-full md:w-4/5">
-                <BarChart v-if="studyData" :options="numberOfActorsData"
-                        @chartSeriesClick="handleDataChartSeriesClick"></BarChart>
-            </div>
-        </div>
-        <div v-if="selectedStage">
-            <MiniChartContainer :currentStage="selectedStage" title="Number of actors">
-                <div class="flex flex-row w-full justify-evenly mt-6">
-                    <div class="w-full flex flex-row justify-center">
-                        <Ring :options="currentStageNumberOfActorsByTypeOfActorData"></Ring>
-                    </div>
+    <div>
+        <InfoTitle title="Number of actors" class="mb-4 mt-8" />
+        <div class="flex flex-col mt-4">
+            <div class="flex flex-row flex-wrap items-center justify-center">
+                <div class="w-1/2 md:w-1/5">
+                    <NiceMetric label="Number of actors" :value="totalNumberOfActors" />
                 </div>
-            </MiniChartContainer>
+                <div class="w-full md:w-4/5">
+                    <BarChart v-if="studyData" :options="numberOfActorsData"
+                            @chartSeriesClick="handleDataChartSeriesClick"></BarChart>
+                </div>
+            </div>
+            <div v-if="selectedStage">
+                <MiniChartContainer :currentStage="selectedStage" title="Number of actors">
+                    <div class="flex flex-row w-full justify-evenly mt-6">
+                        <div class="w-full flex flex-row justify-center">
+                            <Ring :options="currentStageNumberOfActorsByTypeOfActorData"></Ring>
+                        </div>
+                    </div>
+                </MiniChartContainer>
+            </div>
         </div>
     </div>
 </template>

--- a/src/components/study/inclusiveness/EmploymentDistributionJobs.vue
+++ b/src/components/study/inclusiveness/EmploymentDistributionJobs.vue
@@ -2,7 +2,7 @@
     <div>
         <InfoTitle title="Jobs" class="mt-8" />
         <div class="flex flex-col mb-8">
-            <div class="flex flex-row flex-wrap items-start justify-center">
+            <div class="flex flex-row flex-wrap items-center justify-center">
                 <div class="w-1/2 md:w-1/5 flex flex-col space-y-4 pt-8">
                     <NiceMetric label="Waged employment" :value="totalNumberOfJobs" />
                     <NiceMetric label="% female employment" :value="`${percentFemaleEmployment}`" />

--- a/src/components/study/inclusiveness/EmploymentDistributionJobs.vue
+++ b/src/components/study/inclusiveness/EmploymentDistributionJobs.vue
@@ -1,48 +1,50 @@
 <template>
-    <InfoTitle title="Jobs" class="mt-8" />
-    <div class="flex flex-col mb-8">
-        <div class="flex flex-row flex-wrap items-start justify-center">
-            <div class="w-1/2 md:w-1/5 flex flex-col space-y-4 pt-8">
-                <NiceMetric label="Waged employment" :value="totalNumberOfJobs" />
-                <NiceMetric label="% female employment" :value="`${percentFemaleEmployment}`" />
-            </div>
-            <div class="w-full md:w-4/5">
-                <BarChart v-if="studyData" :options="numberOfJobsData"
-                    @chartSeriesClick="handleDataChartSeriesClick"></BarChart>
-            </div>
-        </div>
-        <div v-if="selectedStage">
-            <MiniChartContainer :currentStage="selectedStage" title="Employment">
-                <div class="flex flex-row w-full justify-evenly mt-6">
-                    <template v-if="studyData">
-                        <template v-if="currentStageEmploymentByTypeOfActorData">
-                            <div class="w-1/3 aspect-w-1 aspect-h-1">
-                            <Ring :options="currentStageEmploymentByTypeOfActorData"
-                            style="height: 300px;"></Ring>
-                        </div>
-                    </template>
-                    <template v-if="currentStageEmploymentByQualificationData">
-                        <div class="w-1/3 aspect-w-1 aspect-h-1">
-                            <Ring v-if="studyData" :options="currentStageEmploymentByQualificationData"
-                            style="height: 300px;"></Ring>
-                        </div>
-                    </template>
-                    <template v-else>
-                        <p>No data about job's qualification</p>
-                    </template>
-                    <template v-if="currentStageEmploymentByGenderData">
-                        <div class="w-1/3 aspect-w-1 aspect-h-1">
-                            <Ring v-if="studyData" :options="currentStageEmploymentByGenderData" style="height: 300px;">
-                            </Ring>
-                        </div>
-                    </template>
-                    <template v-else>
-                        <p>No data about job's gender</p>
-                    </template>
-                </template>
-                    
+    <div>
+        <InfoTitle title="Jobs" class="mt-8" />
+        <div class="flex flex-col mb-8">
+            <div class="flex flex-row flex-wrap items-start justify-center">
+                <div class="w-1/2 md:w-1/5 flex flex-col space-y-4 pt-8">
+                    <NiceMetric label="Waged employment" :value="totalNumberOfJobs" />
+                    <NiceMetric label="% female employment" :value="`${percentFemaleEmployment}`" />
                 </div>
-            </MiniChartContainer>
+                <div class="w-full md:w-4/5">
+                    <BarChart v-if="studyData" :options="numberOfJobsData"
+                        @chartSeriesClick="handleDataChartSeriesClick"></BarChart>
+                </div>
+            </div>
+            <div v-if="selectedStage">
+                <MiniChartContainer :currentStage="selectedStage" title="Employment">
+                    <div class="flex flex-row w-full justify-evenly mt-6">
+                        <template v-if="studyData">
+                            <template v-if="currentStageEmploymentByTypeOfActorData">
+                                <div class="w-1/3 aspect-w-1 aspect-h-1">
+                                <Ring :options="currentStageEmploymentByTypeOfActorData"
+                                style="height: 300px;"></Ring>
+                            </div>
+                        </template>
+                        <template v-if="currentStageEmploymentByQualificationData">
+                            <div class="w-1/3 aspect-w-1 aspect-h-1">
+                                <Ring v-if="studyData" :options="currentStageEmploymentByQualificationData"
+                                style="height: 300px;"></Ring>
+                            </div>
+                        </template>
+                        <template v-else>
+                            <p>No data about job's qualification</p>
+                        </template>
+                        <template v-if="currentStageEmploymentByGenderData">
+                            <div class="w-1/3 aspect-w-1 aspect-h-1">
+                                <Ring v-if="studyData" :options="currentStageEmploymentByGenderData" style="height: 300px;">
+                                </Ring>
+                            </div>
+                        </template>
+                        <template v-else>
+                            <p>No data about job's gender</p>
+                        </template>
+                    </template>
+                        
+                    </div>
+                </MiniChartContainer>
+            </div>
         </div>
     </div>
 </template>

--- a/src/components/study/inclusiveness/NetOperatingProfit.vue
+++ b/src/components/study/inclusiveness/NetOperatingProfit.vue
@@ -1,17 +1,19 @@
 <template>
-    <InfoTitle title="Net operating profit across types of actors"/>
-    <div class="flex flex-row items-center mt-4 mb-4">
-        <div class="w-full">
-            <BarChart v-if="studyData" :options="netOperatingProfitData"
-            @chartSeriesClick="handleDataChartSeriesClick"></BarChart>
-            <MiniChartContainer v-if="selectedStage" :currentStage="selectedStage" title="Net Operating Profit">
-                <div class="flex flex-row w-full justify-evenly mt-6">
-                    <div class="w-full flex flex-row justify-center">
-                        <Ring :options="currentStageNetOperatingProfitByTypeOfActorData"
-                            style="height: 300px; width: 450px"></Ring>
+    <div>
+        <InfoTitle title="Net operating profit across types of actors"/>
+        <div class="flex flex-row items-center mt-4 mb-4">
+            <div class="w-full">
+                <BarChart v-if="studyData" :options="netOperatingProfitData"
+                @chartSeriesClick="handleDataChartSeriesClick"></BarChart>
+                <MiniChartContainer v-if="selectedStage" :currentStage="selectedStage" title="Net Operating Profit">
+                    <div class="flex flex-row w-full justify-evenly mt-6">
+                        <div class="w-full flex flex-row justify-center">
+                            <Ring :options="currentStageNetOperatingProfitByTypeOfActorData"
+                                style="height: 300px; width: 450px"></Ring>
+                        </div>
                     </div>
-                </div>
-            </MiniChartContainer>
+                </MiniChartContainer>
+            </div>
         </div>
     </div>
 </template>

--- a/src/components/study/inclusiveness/NetOperatingProfitPerActor.vue
+++ b/src/components/study/inclusiveness/NetOperatingProfitPerActor.vue
@@ -1,16 +1,18 @@
 <template>
-    <InfoTitle title="Mean net operating profit across types of actors"/>
-    <div class="flex flex-row items-center mt-4">
-        <div class="w-full">
-            <BarChart v-if="studyData" :options="netOperatingProfitByNumberActorsData"
-            @chartSeriesClick="handleDataChartSeriesClick"></BarChart>
-            <MiniChartContainer v-if="selectedStage" :currentStage="selectedStage" title="Net Operating Profit per actor">
-                <div class="flex flex-row w-full justify-evenly mt-6">
-                    <div class="w-full flex flex-row justify-center">
-                        <Ring :options="currentStageSplitData"></Ring>
+    <div>
+        <InfoTitle title="Mean net operating profit across types of actors"/>
+        <div class="flex flex-row items-center mt-4">
+            <div class="w-full">
+                <BarChart v-if="studyData" :options="netOperatingProfitByNumberActorsData"
+                @chartSeriesClick="handleDataChartSeriesClick"></BarChart>
+                <MiniChartContainer v-if="selectedStage" :currentStage="selectedStage" title="Net Operating Profit per actor">
+                    <div class="flex flex-row w-full justify-evenly mt-6">
+                        <div class="w-full flex flex-row justify-center">
+                            <Ring :options="currentStageSplitData"></Ring>
+                        </div>
                     </div>
-                </div>
-            </MiniChartContainer>
+                </MiniChartContainer>
+            </div>
         </div>
     </div>
 </template>

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -62,13 +62,6 @@ p {
     padding: 1.5rem 6rem;
 }
 
-.TODO {
-    min-height: 1rem;
-    min-width: 1rem;
-    background-color: pink;
-    border: 5px dashed red;
-}
-
 select {
     -webkit-appearance: none;
     appearance: none;


### PR DESCRIPTION
# Contexte

Après avoir fait la refont de Overview & Economic growth, on en profite pour etendre les améliorations (sans que ça soit la  version finale) à la page "Inclusiveness"

### Screenshots

<details>

| Avant | Après |
| ----- | ----- | 
| ![image](https://github.com/user-attachments/assets/9bffe5fe-e8f8-4d0c-a573-717e0a3d184f) | ![image](https://github.com/user-attachments/assets/31d65842-06fb-4db7-9052-46e65fff5efa) |
| ![image](https://github.com/user-attachments/assets/51bab8a4-822d-4606-8bcf-9a9807762cc4) | ![image](https://github.com/user-attachments/assets/2ab9b782-3846-4fae-aec0-6d61df75b8e3) |
| ![image](https://github.com/user-attachments/assets/789f46b9-0fb7-4c53-9c01-9ad68ba89f5a) | ![image](https://github.com/user-attachments/assets/4b924044-737b-4a8f-97b5-d1c1be3e4145) |

</details>

# Changements

Utilisation des nouveaux `QuestionTitle` et `NoDataBadge`.

## :warning: PR stacked

Je pense merger celle ci dans l'autre branche, puis merger dans main. C'était pour séparer les PRs sans attendre que la première soit merged.