### PR TITLE
refactor: Have study ids stored in the url of the comparison page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,6 @@ import { RouterView } from 'vue-router'
 </script>
 
 <template>
-  <RouterView :key="$route.fullPath"/>
+  <RouterView/>
 </template>
 

--- a/src/components/home/ByCategory.vue
+++ b/src/components/home/ByCategory.vue
@@ -2,6 +2,7 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { getLink } from '@utils/router'
 import { getCountry, getProduct } from '@utils/data.js'
+import { getStudyListQueryString } from '@utils/router.js'
 import LogoCountrySmall from './LogoCountrySmall.vue';
 import LogoCountryLarge from './LogoCountryLarge.vue';
 import LogoProductLarge from './LogoProductLarge.vue';
@@ -11,6 +12,7 @@ import CardFooter from './CardFooter.vue';
 import NumberBadge from './NumberBadge.vue';
 import Card from './Card.vue';
 import SubCardsList from './SubCardsList.vue'
+
 const props = defineProps({
     studies: Array,
     countries: Array,
@@ -78,7 +80,7 @@ const getStudiesByProduct = () => {
                             </template>
                             <template v-slot:footer>
                                 <SubCardsList v-if="openedProduct === item.product" 
-                                :link="{ name: 'comparison', query: { studies: item.studies.map(study => study.id) } }"
+                                :link="{ name: 'comparison', query: { studies: getStudyListQueryString(item.studies.map(study => study.id)) } }"
                                 :linkTitle="`Compare all ${item.product} studies`">
                                     <Card v-for="study in item.studies" :key="study.id"
                                             :link="getLink(study, currency)"

--- a/src/components/home/ByCategory.vue
+++ b/src/components/home/ByCategory.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue'
-import { getLink, getCompareProductLink } from '@utils/router'
+import { getLink } from '@utils/router'
 import { getCountry, getProduct } from '@utils/data.js'
 import LogoCountrySmall from './LogoCountrySmall.vue';
 import LogoCountryLarge from './LogoCountryLarge.vue';
@@ -78,7 +78,7 @@ const getStudiesByProduct = () => {
                             </template>
                             <template v-slot:footer>
                                 <SubCardsList v-if="openedProduct === item.product" 
-                                :link="`/comparison/${getCompareProductLink(item.product)}`"
+                                :link="{ name: 'comparison', query: { studies: item.studies.map(study => study.id) } }"
                                 :linkTitle="`Compare all ${item.product} studies`">
                                     <Card v-for="study in item.studies" :key="study.id"
                                             :link="getLink(study, currency)"

--- a/src/components/home/ByContinent.vue
+++ b/src/components/home/ByContinent.vue
@@ -2,6 +2,7 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { getLink } from '@utils/router'
 import { getCountry, getProduct } from '@utils/data.js'
+import { getStudyListQueryString } from '@utils/router.js'
 import LogoProductLarge from './LogoProductLarge.vue';
 import LogoProductSmall from './LogoProductSmall.vue';
 import LogoCountryLarge from './LogoCountryLarge.vue';
@@ -88,7 +89,7 @@ const getStudiesByCountry = () => {
                         </template>
                         <template v-slot:footer>
                             <SubCardsList v-if="openedCountry === item.country"
-                                :link="{ name: 'comparison', query: { studies: item.studies.map(study => study.id) } }"
+                                :link="{ name: 'comparison', query: { studies: getStudyListQueryString(item.studies.map(study => study.id)) } }"
                                 :linkTitle="`Compare all ${item.country} studies`">
                             <Card v-for="study in item.studies" :key="study.id"
                                 :link="getLink(study, currency)"

--- a/src/components/home/ByContinent.vue
+++ b/src/components/home/ByContinent.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue';
-import { getLink, getCompareCountryLink } from '@utils/router'
+import { getLink } from '@utils/router'
 import { getCountry, getProduct } from '@utils/data.js'
 import LogoProductLarge from './LogoProductLarge.vue';
 import LogoProductSmall from './LogoProductSmall.vue';
@@ -88,7 +88,7 @@ const getStudiesByCountry = () => {
                         </template>
                         <template v-slot:footer>
                             <SubCardsList v-if="openedCountry === item.country"
-                                :link="`/comparison/${getCompareCountryLink(item.country)}`"
+                                :link="{ name: 'comparison', query: { studies: item.studies.map(study => study.id) } }"
                                 :linkTitle="`Compare all ${item.country} studies`">
                             <Card v-for="study in item.studies" :key="study.id"
                                 :link="getLink(study, currency)"

--- a/src/components/home/SubCardsList.vue
+++ b/src/components/home/SubCardsList.vue
@@ -3,7 +3,7 @@ import { RouterLink } from 'vue-router';
 
 const props = defineProps({
     link: {
-        type: String,
+        type: Object,
         required: false
     },
     linkTitle: {

--- a/src/components/study/StudyMenu.vue
+++ b/src/components/study/StudyMenu.vue
@@ -2,14 +2,19 @@
     <nav class="flex flex-col">
         <div class="text-[#868686] mb-2">Contents</div>
         <ol class="text-[#2E6BAD] space-y-2">
-            <li v-for="(route, indexRoute) in routes" :key="indexRoute">
-                <RouterLink 
-                    :to="`/study?id=${isLocalStudy ? 'localStorage' : studyId}${route.view ? `&view=${route.view}` : ''}&currency=${currency}`"
-                    :class="{ disabled: !route.accessible}"
-                >{{ route.label }}</RouterLink>
+            <li v-for="(view, index) in views" :key="index">
+                <a 
+                    class="hover:underline cursor-pointer"
+                    :class="{ disabled: !view.accessible}"
+                    @click="emits('select', view.key)"
+                >{{ view.label }}</a>
             </li>
             <li>
-                <a v-if="fullReportPdfUrl" :href="fullReportPdfUrl">Study full report</a>
+                <a
+                    v-if="fullReportPdfUrl"
+                    class="hover:underline cursor-pointer"
+                    :href="fullReportPdfUrl"
+                >Study full report</a>
             </li>
         </ol>
         <div v-if="localCurrency">
@@ -19,8 +24,8 @@
                     id="currencies"
                     class="border border-[#656565] text-[#868686] rounded-lg focus:ring-[#868686] focus:border-[#868686] block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
                     v-model="selectedCurrency"
-                    @change="$emit('update:currency', $event.target.value)"
-                    >
+                    @change="emits('update:currency', $event.target.value)"
+                >
                     <option v-if="isCurrencySupported(localCurrency)" value="LOCAL">{{ getCurrencyName(localCurrency) }} ({{ getCurrencySymbol(localCurrency) }})</option>
                     <option v-else value="LOCAL">{{ localCurrency }} ({{  getCurrencySymbol(localCurrency) }})</option>
                     <option v-if="localCurrency !== 'USD' && isCurrencySupported(localCurrency)" value="USD">{{ getCurrencyName("USD") }} ({{ getCurrencySymbol("USD") }})</option>
@@ -32,47 +37,17 @@
 </template>
 
 <script setup>
-    import { ref} from 'vue'
+    import { ref, defineEmits } from 'vue'
 
     import { getCurrencySymbol, getCurrencyName, isCurrencySupported } from '@utils/currency.js'
     const props = defineProps({
-        studyId: String,
+        views: Array,
         localCurrency : String,
         currency: String,
-        isLocalStudy: Boolean,
-        hasEco: Boolean,
-        hasSocial: Boolean,
-        hasACV: Boolean,
         fullReportPdfUrl: String,
     })
+    const emits = defineEmits(["select"])
     const selectedCurrency = ref(props.currency);
-    const routes = [
-        {
-            view: undefined,
-            label: 'Functional Analysis',
-            accessible: (props.hasEco + props.hasSocial + props.hasACV) >= 2
-        },
-        {
-            view: 'economic-growth',
-            label: 'Contribution to economic growth',
-            accessible: props.hasEco
-        },
-        {
-            view: 'inclusiveness',
-            label: 'Inclusiveness',
-            accessible: props.hasEco
-        },
-        {
-            view: 'social-sustainability',
-            label: 'Social sustainability',
-            accessible: props.hasSocial
-        },
-        {
-            view: 'environment',
-            label: 'Environmental sustainability',
-            accessible: props.hasACV
-        }
-    ]
 </script>
 
 <style scoped lang="scss">

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,7 +23,7 @@ const router = createRouter({
             component: Import
         },
         {
-            path: '/comparison/:params?',
+            path: '/comparison',
             name: 'comparison',
             component: Comparison
         },

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -51,6 +51,7 @@ p {
 }
 #app {
     width: 100%;
+    min-height: 100vh;
 
     display: flex;
     flex-direction: column;

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -28,26 +28,6 @@ export const getFullReportPdfPath = async (studyId) => {
     return null
 }
 
-export const getStudiesByCountry = async (countryId) => {
-    const studyIds = jsonData.studies.filter(study => study.country === countryId).map(study => study.id)
-    let ret = []
-    for (const studyId of studyIds) {
-        const study = await getStudyData(studyId)
-        ret.push(study)
-    }
-    return ret
-}
-
-export const getStudiesByProduct = async (productId) => {
-    const studyIds = jsonData.studies.filter(study => study.product === productId).map(study => study.id)
-    let ret = []
-    for (const studyId of studyIds) {
-        const study = await getStudyData(studyId)
-        ret.push(study)
-    }
-    return ret
-}
-
 export const getStudyData = async (studyId) => {
     if (studyId === LOCAL_STORAGE_ID) {
         const localStudyData = localStorage.getItem('localStudyData')

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,15 +1,1 @@
 export const getLink = (study, currency) => `/study?id=${study.local ? 'localStorage' : study.id}&currency=${currency}`
-
-export const getCompareCountryLink = (countryId) => {
-    const params = new URLSearchParams({
-        country: countryId
-    })
-    return params.toString()
-}
-
-export const getCompareProductLink = (productId) => {
-    const params = new URLSearchParams({
-        product: productId
-    })
-    return params.toString()
-}

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,1 +1,8 @@
 export const getLink = (study, currency) => `/study?id=${study.local ? 'localStorage' : study.id}&currency=${currency}`
+
+export function getStudyListQueryString(studyIds) {
+    return studyIds.join(",");
+}
+export function extractStudiesFromQueryString(queryString) {
+    return queryString.split(",");
+}

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -2,7 +2,13 @@
     <Skeleton>
         <div class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 max-w-[90%] lg:w-[80%]">
             <h1>Compare VCA4D Value chain studies</h1>
-            <StudiesComparison :studies="studies"></StudiesComparison>
+            <StudiesComparison
+                v-if="studies.length > 0"
+                :studies="studies"
+            />
+            <div class="no-study" v-else>
+                No study is selected
+            </div>
         </div>  
     </Skeleton>
 </template>
@@ -31,4 +37,13 @@ watch(route, async () => {
 </script>
 
 <style scoped lang="scss">
+.no-study {
+    display:flex;
+    justify-content: center;
+    padding: 64px 16px;
+    margin-bottom: 32px;
+    background-color: #ededed;
+    border-radius: 8px;
+    width: 100%;
+}
 </style>

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -6,7 +6,7 @@
                 v-if="studies.length > 0"
                 :studies="studies"
             />
-            <div class="no-study" v-else>
+            <div class="no-study" v-else-if="loading === false">
                 No study is selected
             </div>
         </div>  
@@ -23,6 +23,7 @@ import { extractStudiesFromQueryString } from '@utils/router';
 
 const route = useRoute();
 
+const loading = ref(false);
 const studies = ref([])
 
 watch(route, async () => {
@@ -31,7 +32,9 @@ watch(route, async () => {
         return;
     }
     const studyIds = extractStudiesFromQueryString(route.query.studies);
+    loading.value = true;
     studies.value = await Promise.all(studyIds.map(getStudyData))
+    loading.value = false;
 }, { immediate: true })
 
 </script>

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -9,26 +9,19 @@
 
 <script setup>
 import Skeleton from '@components/Skeleton.vue';
-import { onMounted, ref } from 'vue';
+import { watch, ref } from 'vue';
 import { useRoute } from 'vue-router'
-import { getStudiesByProduct, getStudiesByCountry } from '@utils/data';
+import { getStudyData } from '@utils/data';
 import StudiesComparison from '../components/StudiesComparison.vue';
 
 const route = useRoute();
 
 const studies = ref([])
-onMounted(async () => {
-    const params = route.params.params || "country=ecuador"
-    const [key, value ] = params.split('=')
-    if (key === 'country') {
-        studies.value = await getStudiesByCountry(value)
-        return
-    }
-    if (key === 'product') {
-        studies.value = await getStudiesByProduct(value)
-        return
-    }
-})
+
+watch(route, async () => {
+    const studyIds = route.query.studies;
+    studies.value = await Promise.all(studyIds.map(getStudyData))
+}, { immediate: true })
 
 </script>
 

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -13,13 +13,18 @@ import { watch, ref } from 'vue';
 import { useRoute } from 'vue-router'
 import { getStudyData } from '@utils/data';
 import StudiesComparison from '../components/StudiesComparison.vue';
+import { extractStudiesFromQueryString } from '@utils/router';
 
 const route = useRoute();
 
 const studies = ref([])
 
 watch(route, async () => {
-    const studyIds = route.query.studies;
+    if (! route.query.studies) { 
+        studies.value = [];
+        return;
+    }
+    const studyIds = extractStudiesFromQueryString(route.query.studies);
     studies.value = await Promise.all(studyIds.map(getStudyData))
 }, { immediate: true })
 

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -43,7 +43,7 @@ import StudyInclusiveness from '@components/StudyInclusiveness.vue'
 import StudySocialSustainability from '@components/StudySocialSustainability.vue'
 import StudyHeader from '@components/study/StudyHeader.vue'
 import StudyMenu from '@components/study/StudyMenu.vue'
-import { getStudyData, LOCAL_STORAGE_ID } from '@utils/data.js'
+import { getStudyData } from '@utils/data.js'
 
 const route = useRoute();
 const router = useRouter()
@@ -55,7 +55,6 @@ const updateCurrency = (event) => {
 
 const studyData = ref(null)
 const error = ref(undefined)
-const isLocal = ref(undefined)
 
 watch(currency, (newCurrency) => {
     router.push({ query: 
@@ -140,8 +139,6 @@ onMounted(async () => {
     currency.value = localStorage.getItem('currency')
   }
 
-  const isLocalStudy = studyId === LOCAL_STORAGE_ID
-  isLocal.value =  isLocalStudy
   try {
     studyData.value = await getStudyData(studyId)
     

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch, computed } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import Skeleton from '@components/Skeleton.vue'
 import StudyOverview from '@components/StudyOverview.vue'

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -12,23 +12,21 @@
             </header>
             <div class="w-full text-left ml-24 my-8">
                 <StudyMenu 
-                    v-if="studyData"  
-                    :studyId="studyData.id" 
-                    :localCurrency="studyData.targetCurrency" 
-                    :currency="currency"
-                    :isLocalStudy="isLocal"
-                    :hasEco="!!studyData.ecoData"
-                    :hasSocial="!!studyData.socialData"
-                    :hasACV="!!studyData.acvData"
-                    :fullReportPdfUrl="studyData.fullReportPdfUrl"
-                @update:currency="updateCurrency" />
+                  v-if="!! studyData"
+                  :views="views"
+                  :localCurrency="studyData.targetCurrency" 
+                  :currency="currency"
+                  :fullReportPdfUrl="studyData.fullReportPdfUrl"
+                  @update:currency="updateCurrency"
+                  @select="selectView($event)"
+                />
             </div>
              <template v-if="studyData">
-                <StudyOverview v-if="view === undefined" :studyData="studyData"></StudyOverview>
-                <StudyEnvironment v-if="view === 'environment'" :studyData="studyData"></StudyEnvironment>
-                <StudyEconomicGrowth v-if="view === 'economic-growth'" :studyData="studyData" :currency="currencySymbol"></StudyEconomicGrowth>
-                <StudyInclusiveness v-if="view === 'inclusiveness'" :studyData="studyData" :currency="currencySymbol"></StudyInclusiveness>
-                <StudySocialSustainability v-if="view === 'social-sustainability'" :studyData="studyData"></StudySocialSustainability>
+                <component
+                  :is="viewComponent"
+                  :studyData="studyData"
+                  :currency="currencySymbol"
+                />
             </template>
         </div>
     </Skeleton>
@@ -55,17 +53,9 @@ const updateCurrency = (event) => {
     currency.value = event
 }
 
-const studyData = ref(undefined)
+const studyData = ref(null)
 const error = ref(undefined)
 const isLocal = ref(undefined)
-
-const TypeOfViews = {
-    overview: undefined,
-    environment: "environment",
-    'economic-growth': 'economic-growth',
-    inclusiveness: "inclusiveness",
-    'social-sustainability': 'social-sustainability'
-}
 
 watch(currency, (newCurrency) => {
     router.push({ query: 
@@ -79,7 +69,67 @@ watch(currency, (newCurrency) => {
 
 const currencySymbol = computed( () => currency.value === 'LOCAL' ? studyData.value.targetCurrency : currency.value);
 
-const view = ref(undefined)
+const views = computed(() => {
+  if (!studyData.value) { return []; }
+  
+  const hasEco = !!studyData.value.ecoData;
+  const hasSocial = !!studyData.value.socialData;
+  const hasACV = !!studyData.value.acvData;
+  return [
+    {
+      key: "overview",
+      label: 'Functional Analysis',
+      accessible: [hasEco, hasSocial, hasACV].filter(hasStudyPart => hasStudyPart).length >= 2,
+      component: StudyOverview
+    },
+    {
+      key: 'economic-growth',
+      label: 'Contribution to economic growth',
+      accessible: hasEco,
+      component: StudyEconomicGrowth
+    },
+    {
+      key: 'inclusiveness',
+      label: 'Inclusiveness',
+      accessible: hasEco,
+      component: StudyInclusiveness
+    },
+    {
+      key: 'social-sustainability',
+      label: 'Social sustainability',
+      accessible: hasSocial,
+      component: StudySocialSustainability
+    },
+    {
+      key: 'environment',
+      label: 'Environmental sustainability',
+      accessible: hasACV,
+      component: StudyEnvironment
+    }
+  ]
+});
+
+const view = computed(() => {
+  return route.query.view || findFirstAvailableView();
+
+  function findFirstAvailableView() {
+    const accessibleViews = views.value.filter(view => view.accessible);
+    return accessibleViews[0].key;
+  }
+})
+
+const viewComponent = computed(() => {
+  const viewConfig = views.value.find(viewConfig => viewConfig.key === view.value);
+  return viewConfig?.component || null;
+});
+
+function selectView(viewKey) {
+  router.push({ query: {
+    ...route.query,
+    view: viewKey
+  } });
+}
+
 onMounted(async () => {
   const studyId = route.query.id;
   const currencyFromUrl = route.query.currency
@@ -101,30 +151,7 @@ onMounted(async () => {
   } catch(err) {
     error.value = err;
   }
-
-  view.value = TypeOfViews.overview
-  if (route.query.view) {
-    view.value = route.query.view;
-  }
-  else {
-    // Heuristique pour savoir si ça vaut le coup d'afficher la page overview, ou directement la seule page disponible de l'étude
-    let possibleStudyParts = ["ecoData", "acvData", "socialData", "briefReportPdfUrl"]
-    let availableParts = possibleStudyParts.filter(part => studyData.value[part])
-    if (availableParts.length == 1 && availableParts[0] != "ecoData") {
-      if (availableParts[0] == "acvData") {
-        view.value = TypeOfViews.environment
-      }
-      else if (availableParts[0] == "socialData") {
-        view.value = TypeOfViews['social-sustainability']
-      }
-    }
-  }
 })
-
-const onBeforeRouteUpdate = (to, from) => {
-  const view = to.query.view;
-  view.value = view;
-};
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
Resolves #37 

## Contexte

On veut faire une page de comparaison dynamique, en stockant les id des etudes dans l'url

Screenshot

<details>

![image](https://github.com/user-attachments/assets/1e18665e-e0ae-4e7e-a15e-5ffb1d7fa709)

</details>

## Changements

- Refactor: Suppression de `:key` sur le router: les composants doivent gerer dynamiquement leurs enfants, et ne pas se baser sur le rechargemenbt complet de l'app a chaque changement
- Un peu de boyscout
- Passage des study ids dans la route.query pour etre lue par la page `Comparison`
- Affichage d'un message "pas détude" si on n'en selectionne aucune