### PR TITLE
feat: Add study selector for comparison page

### DIFF
--- a/data/inland-fisheries-mali/inland-fisheries-mali-social.json
+++ b/data/inland-fisheries-mali/inland-fisheries-mali-social.json
@@ -1,7 +1,7 @@
 {
-  "id": "inland-fishery-mali",
+  "id": "inland-fisheries-mali",
   "country": "mali",
-  "commodity": "inland fishery",
+  "commodity": "inland fisheries",
   "year": 2020,
   "type": "social",
   "socialData": [

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,0 +1,63 @@
+<template>
+  <Teleport to="body">
+    <div v-if="opened" class="modal-overlay">
+      <div class="modal">
+        <slot></slot>
+        <a class="exit-button" @click="emits('close')">
+          <Svg :svg="Cross"/>
+        </a>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import Svg from "@components/Svg.vue";
+import Cross from "../images/icons/cross.svg";
+defineProps({
+  opened: Boolean
+});
+
+const emits = defineEmits(["close"]);
+
+</script>
+
+<style scoped lang="scss">
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  background-color: rgba($color: black, $alpha: 0.5);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .modal {
+    min-width: 300px;
+    min-height: 100px;
+    padding: 20px 50px;
+    border-radius: 12px;
+    background-color: white;
+    position: relative;
+
+    .exit-button {
+      position: absolute;
+      top: 20px;
+      right: 20px;
+      height: 20px;
+      width: 20px;
+      color: #6B6B6B;
+
+      &:hover {
+        color: #404040;
+      }
+
+      cursor: pointer;
+    }
+  }
+}
+</style>

--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -77,7 +77,7 @@ td:first-child {
 .right-border {
     @apply border-r-2
 }
-tr td:not(:first-child):not(:last-child) {
+tr td:not(:first-child):not(:last-child):not(:nth-last-child(2)) {
   @apply border-r-2
 }
 tr.rounded td:not(:first-child) div {
@@ -86,7 +86,7 @@ tr.rounded td:not(:first-child) div {
 tr.rounded td:nth-child(2) div{
     @apply rounded-l-full
 }
-tr.rounded td:last-child div {
+tr.rounded td:nth-last-child(2) div {
     @apply rounded-r-full
 }
 </style>

--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -16,8 +16,6 @@
             <ComparisonEnvironment :studies="studies" />
         </tbody>
     </table>
-    <div>
-    </div>
 </template>
 
 <script setup>
@@ -42,10 +40,11 @@ td {
     @apply w-1/5
 }
 td.title {
-    @apply uppercase text-[#8A8A8A] font-bold text-sm pb-4
+    @apply uppercase text-[#8A8A8A] font-bold text-sm pb-4;
 }
-tr {
-    @apply flex flex-row
+td:first-child {
+    min-width: 220px;
+    padding-right: 20px;
 }
 .definition {
     @apply text-[#9B9B9B] italic

--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -1,7 +1,10 @@
 <template>
     <table class="w-full">
         <tbody>
-            <ComparisonHeader :studies="studies" />
+            <ComparisonHeader
+                :studies="studies"
+                @select-studies="emit('select-studies',$event)"
+            />
             <ComparisonEconomics :studies="studies" />
             
             <ComparisonSeparator :studies="studies" />
@@ -27,6 +30,7 @@ import ComparisonEconomics from './comparison/ComparisonEconomics.vue'
 const props = defineProps({
     studies: Array,
 })
+const emit = defineEmits(["select-studies"]);
 
 </script>
 

--- a/src/components/comparison/AddStudiesButton.vue
+++ b/src/components/comparison/AddStudiesButton.vue
@@ -11,6 +11,7 @@
       <div class="modal-title">Select studies to compare</div>
       <StudiesListTable
         :selectedStudies="currentStudySelection"
+        @select-studies="selectStudies($event)"
       />
     </Modal>
   </div>
@@ -28,6 +29,13 @@
   })
 
   const opened = ref(false);
+
+  const emits = defineEmits(["select-studies"]);
+
+  function selectStudies(studySelection) {
+    opened.value = false;
+    emits("select-studies", studySelection);
+  }
 </script>
 
 <style scoped lang="scss">

--- a/src/components/comparison/AddStudiesButton.vue
+++ b/src/components/comparison/AddStudiesButton.vue
@@ -1,0 +1,32 @@
+<template>
+  <a class="add-studies-button">
+    <Svg class="plus" :svg="PlusLogo"/>
+    <div>Add studies</div>
+  </a>
+</template>
+
+<script setup>
+  import PlusLogo from '../../images/icons/plus.svg'
+  import Svg from "@components/Svg.vue"
+</script>
+
+<style scoped lang="scss">
+  .add-studies-button {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: #3F83F8;
+    text-align: center;
+    min-width: 100px;
+
+    .plus {
+      height: 30px;
+    }
+
+    &:hover {
+      color: #1C64F2;
+    }
+  }
+</style>

--- a/src/components/comparison/AddStudiesButton.vue
+++ b/src/components/comparison/AddStudiesButton.vue
@@ -1,13 +1,33 @@
 <template>
-  <a class="add-studies-button">
-    <Svg class="plus" :svg="PlusLogo"/>
-    <div>Add studies</div>
-  </a>
+  <div>
+    <a class="add-studies-button" @click="opened = true">
+      <Svg class="plus" :svg="PlusLogo"/>
+      <div>Add studies</div>
+    </a>
+    <Modal
+      :opened="opened"
+      @close="opened = false"
+    >
+      <div class="modal-title">Select studies to compare</div>
+      <StudiesListTable
+        :selectedStudies="currentStudySelection"
+      />
+    </Modal>
+  </div>
 </template>
 
 <script setup>
+  import { ref } from 'vue';
   import PlusLogo from '../../images/icons/plus.svg'
   import Svg from "@components/Svg.vue"
+  import Modal from "@components/Modal.vue"
+  import StudiesListTable from './StudiesListTable.vue';
+
+  defineProps({
+    currentStudySelection: Array
+  })
+
+  const opened = ref(false);
 </script>
 
 <style scoped lang="scss">
@@ -28,5 +48,9 @@
     &:hover {
       color: #1C64F2;
     }
+  }
+  .modal-title {
+    font-size: 40px;
+    margin-bottom: 20px;
   }
 </style>

--- a/src/components/comparison/ComparisonEconomicsItem.vue
+++ b/src/components/comparison/ComparisonEconomicsItem.vue
@@ -9,6 +9,7 @@
                 {{ values[index] ? format(values[index]) : '-' }}
             </div>
         </td>
+        <td></td>
     </tr>
 </template>
 

--- a/src/components/comparison/ComparisonEnvironment.vue
+++ b/src/components/comparison/ComparisonEnvironment.vue
@@ -11,6 +11,7 @@
                     {{ formatNumber(getImpactValue(impact, study)) }}
                 </div>
             </td>
+            <td></td>
         </tr>
     </template>
 </template>

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -29,6 +29,7 @@
         <td class="add-studies">
             <AddStudiesButton
                 :currentStudySelection="studiesWithDetails.map(study => study.id)"
+                @select-studies="emits('select-studies', $event)"
             />
         </td>
     </tr>

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -26,6 +26,9 @@
                 </div>
             </div>
         </td>
+        <td class="add-studies">
+            <AddStudiesButton/>
+        </td>
     </tr>
 </template>
 
@@ -40,6 +43,7 @@ import LogoProductLarge from '@components/home/LogoProductLarge.vue';
 import Card from '@components/home/Card.vue';
 import CardFooter from '@components/home/CardFooter.vue';
 import Svg from '@components/Svg.vue';
+import AddStudiesButton from '@components/comparison/AddStudiesButton.vue';
 import CrossLogo from '../../images/icons/cross.svg'
 
 const props = defineProps({
@@ -106,5 +110,10 @@ function removeStudy(studyIdToRemove) {
         display: flex;
         width: 115px;
     }
+}
+.add-studies {
+    display: flex;
+    padding: 30px;
+
 }
 </style>

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -4,13 +4,6 @@
         <td v-for="(study) in studiesWithDetails" :key="`${study.id}`">
             <div class="flex flex-col items-center gap-y-2"
             >
-                <div v-if="study.id" class="flex flex-row items-center justify-center">
-                    <CardFooter :text="study.country_name">
-                        <template v-slot:logo>
-                            <LogoCountrySmall :iso-code="study['country_iso_code'] || 'gr'" />
-                        </template>
-                    </CardFooter>
-                </div>
                 <Card
                     :link="getLink(study, 'LOCAL')"
                     :is-local="false"
@@ -20,6 +13,13 @@
                         <LogoProductLarge :product-name="study.product.id"/>
                     </template>
                 </Card>
+                <div v-if="study.id" class="flex flex-row items-center justify-center">
+                    <CardFooter :text="study.country_name">
+                        <template v-slot:logo>
+                            <LogoCountrySmall :iso-code="study['country_iso_code'] || 'gr'" />
+                        </template>
+                    </CardFooter>
+                </div>
             </div>
         </td>
     </tr>

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -17,7 +17,7 @@
                         <Svg :svg="CrossLogo"/>
                     </a>
                 </div>
-                <div v-if="study.id" class="flex flex-row items-center justify-center">
+                <div v-if="study.id" class="footer">
                     <CardFooter :text="study.country_name">
                         <template v-slot:logo>
                             <LogoCountrySmall :iso-code="study['country_iso_code'] || 'gr'" />
@@ -78,6 +78,7 @@ function removeStudy(studyIdToRemove) {
     flex-direction: column;
     align-items: center;
     gap: 0.5rem;
+    height: 200px;
 
     .card-box {
         position: relative;
@@ -99,6 +100,11 @@ function removeStudy(studyIdToRemove) {
                 background-color: #ffac9e;
             }
         }
+    }
+
+    .footer {
+        display: flex;
+        width: 115px;
     }
 }
 </style>

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -13,7 +13,7 @@
                             <LogoProductLarge :product-name="study.product.id"/>
                         </template>
                     </Card>
-                    <a class="remove-button" @click="removeStudy(study.id)">
+                    <a v-if="IS_COMPARISON_V2_ACTIVATED" class="remove-button" @click="removeStudy(study.id)">
                         <Svg :svg="CrossLogo"/>
                     </a>
                 </div>
@@ -28,6 +28,7 @@
         </td>
         <td class="add-studies">
             <AddStudiesButton
+                v-if="IS_COMPARISON_V2_ACTIVATED"
                 :currentStudySelection="studiesWithDetails.map(study => study.id)"
                 @select-studies="emits('select-studies', $event)"
             />
@@ -49,6 +50,7 @@ import Svg from '@components/Svg.vue';
 import AddStudiesButton from '@components/comparison/AddStudiesButton.vue';
 import CrossLogo from '../../images/icons/cross.svg'
 
+const IS_COMPARISON_V2_ACTIVATED = false;
 const props = defineProps({
     studies: Array,
 })

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -27,7 +27,9 @@
             </div>
         </td>
         <td class="add-studies">
-            <AddStudiesButton/>
+            <AddStudiesButton
+                :currentStudySelection="studiesWithDetails.map(study => study.id)"
+            />
         </td>
     </tr>
 </template>

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -2,17 +2,21 @@
     <tr>
         <td></td>
         <td v-for="(study) in studiesWithDetails" :key="`${study.id}`">
-            <div class="flex flex-col items-center gap-y-2"
-            >
-                <Card
-                    :link="getLink(study, 'LOCAL')"
-                    :is-local="false"
-                    :is-open="false"
-                    :title="study.product.prettyName">
-                    <template v-slot:logo>
-                        <LogoProductLarge :product-name="study.product.id"/>
-                    </template>
-                </Card>
+            <div class="study-box">
+                <div class="card-box">
+                    <Card
+                        :link="getLink(study, 'LOCAL')"
+                        :is-local="false"
+                        :is-open="false"
+                        :title="study.product.prettyName">
+                        <template v-slot:logo>
+                            <LogoProductLarge :product-name="study.product.id"/>
+                        </template>
+                    </Card>
+                    <a class="remove-button" @click="removeStudy(study.id)">
+                        <Svg :svg="CrossLogo"/>
+                    </a>
+                </div>
                 <div v-if="study.id" class="flex flex-row items-center justify-center">
                     <CardFooter :text="study.country_name">
                         <template v-slot:logo>
@@ -35,6 +39,9 @@ import LogoCountrySmall from '@components/home/LogoCountrySmall.vue';
 import LogoProductLarge from '@components/home/LogoProductLarge.vue';
 import Card from '@components/home/Card.vue';
 import CardFooter from '@components/home/CardFooter.vue';
+import Svg from '@components/Svg.vue';
+import CrossLogo from '../../images/icons/cross.svg'
+
 const props = defineProps({
     studies: Array,
 })
@@ -55,7 +62,43 @@ const getStudyDetails = (study) => {
     }
 }
 
+const emits = defineEmits(["select-studies"]);
+
+function removeStudy(studyIdToRemove) {
+    const currentStudyIds = props.studies.map(study => study.id);
+    const newStudySelection = currentStudyIds.filter(studyId => studyId !== studyIdToRemove);
+    emits("select-studies", newStudySelection);
+}
+
 </script>
 
 <style scoped lang="scss">
+.study-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+
+    .card-box {
+        position: relative;
+
+        .remove-button {
+            width: 20px;
+            height: 20px;
+            padding: 5px;
+            border-radius: 100%;
+            background-color: #868686;
+            color: white;
+            cursor: pointer;
+
+            position: absolute;
+            top: -5px;
+            right: -5px;
+
+            &:hover {
+                background-color: #ffac9e;
+            }
+        }
+    }
+}
 </style>

--- a/src/components/comparison/ComparisonSeparator.vue
+++ b/src/components/comparison/ComparisonSeparator.vue
@@ -2,6 +2,7 @@
     <tr class="h-12">
         <td></td>
         <td v-for="study in studies" :key="`${study.id}`"></td>
+        <td></td>
     </tr>
 </template>
 

--- a/src/components/comparison/ComparisonSocial.vue
+++ b/src/components/comparison/ComparisonSocial.vue
@@ -5,8 +5,13 @@
             <div class="subtitle">{{ part }}</div>
         </td>
         <td v-for="study in studies" :key="`${study.id}`">
-            <div class="w-3/4 mx-auto my-2">
-                <Tag v-if="study.socialData" :scale="getSocialAverageGroup(study.socialData, index)" :appreciation="getAppreciation(getSocialAverageGroup(study.socialData, index))" />
+            <div class="tag-container mx-auto my-2">
+                <Tag
+                    v-if="study.socialData"
+                    class="tag"
+                    :scale="getSocialAverageGroup(study.socialData, index)"
+                    :appreciation="getAppreciation(getSocialAverageGroup(study.socialData, index))"
+                />
             </div>
         </td>
     </tr>
@@ -48,4 +53,12 @@ const getAppreciation = (scale) => {
 </script>
 
 <style scoped lang="scss">
+.tag-container {
+    margin: 0.5rem auto;
+    min-width: 200px;
+    .tag {
+        max-width: 80%;
+        margin: 0 auto;
+    }
+}
 </style>

--- a/src/components/comparison/ComparisonSocial.vue
+++ b/src/components/comparison/ComparisonSocial.vue
@@ -14,6 +14,7 @@
                 />
             </div>
         </td>
+        <td></td>
     </tr>
 </template>
 

--- a/src/components/comparison/ComparisonTitle.vue
+++ b/src/components/comparison/ComparisonTitle.vue
@@ -6,6 +6,7 @@
         <td v-for="study in studies" :key="`${study.id}`">
             
         </td>
+        <td></td>
     </tr>
 </template>
 

--- a/src/components/comparison/StudiesListTable.vue
+++ b/src/components/comparison/StudiesListTable.vue
@@ -19,11 +19,14 @@
       />
     </template>
   </TableLite>
+  <div class="footer">
+    <button class="confirm-button" @click="emits('select-studies', newSelectedStudies)">Show comparison</button>
+  </div>
 </template>
 
 <script setup>
   import _ from "lodash";
-  import { onMounted, ref } from 'vue';
+  import { onMounted, ref, computed } from 'vue';
   import TableLite from 'vue3-table-lite';
   import { getAllJsonData, getStudy, getStudyData, getProduct, getCountry } from '@utils/data';
 
@@ -54,6 +57,8 @@
     }
   }
 
+  const emits = defineEmits(["select-studies"]);
+
   const columns = [{
     field: "checkbox"
   }, {
@@ -81,6 +86,25 @@
 <style scoped lang="scss">
 .table {
   overflow-y: scroll;
+}
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10px;
+
+  .confirm-button {
+    color:white;
+    font-weight: 600;
+    padding: 0.5rem 1rem;
+    background-color: #3F83F8;
+    border-radius: 0.25rem;
+    right: 0px;
+    width: 200px;
+
+    &:hover {
+      background-color: #1A56DB;
+    }
+  }
 }
 </style>
 

--- a/src/components/comparison/StudiesListTable.vue
+++ b/src/components/comparison/StudiesListTable.vue
@@ -1,5 +1,6 @@
 <template>
   <TableLite
+    :is-slot-mode="true"
     class="table"
     :isLoading="studies.length === 0"
     :columns="columns"
@@ -8,7 +9,15 @@
     :rows="studies"
     :page-size="50"
     :is-hide-paging="studies.length <= 50"
+    @row-clicked="(rowData) => toggleRowSelection(rowData.id)"
   >
+    <template v-slot:checkbox="{ value: studyData }">
+      <input
+        type="checkbox"
+        :checked="isSelected(studyData.id)"
+        @click.stop="toggleRowSelection(studyData.id)"
+      />
+    </template>
   </TableLite>
 </template>
 
@@ -18,14 +27,36 @@
   import TableLite from 'vue3-table-lite';
   import { getAllJsonData, getStudy, getStudyData, getProduct, getCountry } from '@utils/data';
 
+  const props = defineProps({
+    selectedStudies: Array
+  });
   const studies = ref([]);
+  const newSelectedStudies = ref([]);
 
   onMounted(async () => {
-    const jsonStudies = getAllJsonData().studies;
-    studies.value = await Promise.all(jsonStudies.map(({ id }) => getStudyData(id)))
+    newSelectedStudies.value = props.selectedStudies;
+    studies.value = await loadStudyData();
+
+    async function loadStudyData() {
+      const jsonStudies = getAllJsonData().studies;
+      return Promise.all(jsonStudies.map(({ id }) => getStudyData(id)))
+    }
   });
 
+  function isSelected(studyId) {
+    return newSelectedStudies.value.includes(studyId);
+  }
+  function toggleRowSelection(studyId) {
+    if (newSelectedStudies.value.includes(studyId)) {
+      newSelectedStudies.value = newSelectedStudies.value.filter(id => id !== studyId);
+    } else {
+      newSelectedStudies.value.push(studyId)
+    }
+  }
+
   const columns = [{
+    field: "checkbox"
+  }, {
     label: "Product",
     display: (studyData) => _.capitalize(getProduct(getStudy(studyData.id).product).prettyName)
   }, {
@@ -48,5 +79,8 @@
 </script>
 
 <style scoped lang="scss">
+.table {
+  overflow-y: scroll;
+}
 </style>
 

--- a/src/components/comparison/StudiesListTable.vue
+++ b/src/components/comparison/StudiesListTable.vue
@@ -1,0 +1,52 @@
+<template>
+  <TableLite
+    class="table"
+    :isLoading="studies.length === 0"
+    :columns="columns"
+    :max-height="500"
+    :total="studies.length"
+    :rows="studies"
+    :page-size="50"
+    :is-hide-paging="studies.length <= 50"
+  >
+  </TableLite>
+</template>
+
+<script setup>
+  import _ from "lodash";
+  import { onMounted, ref } from 'vue';
+  import TableLite from 'vue3-table-lite';
+  import { getAllJsonData, getStudy, getStudyData, getProduct, getCountry } from '@utils/data';
+
+  const studies = ref([]);
+
+  onMounted(async () => {
+    const jsonStudies = getAllJsonData().studies;
+    studies.value = await Promise.all(jsonStudies.map(({ id }) => getStudyData(id)))
+  });
+
+  const columns = [{
+    label: "Product",
+    display: (studyData) => _.capitalize(getProduct(getStudy(studyData.id).product).prettyName)
+  }, {
+    label: "Country",
+    display:(studyData) => _.capitalize(getCountry(getStudy(studyData.id).country).prettyName)
+  }, {
+    label: "Macro economic indicators",
+    display: buildAvailibilityDisplay("ecoData")
+  }, {
+    label: "Social sustainability",
+    display: buildAvailibilityDisplay("socialData")
+  }, {
+    label: "Environmental analysis",
+    display: buildAvailibilityDisplay("acvData")
+  }];
+
+  function buildAvailibilityDisplay(dataKey) {
+    return (studyData) => !! studyData[dataKey] ? "Available" : "-"
+  }
+</script>
+
+<style scoped lang="scss">
+</style>
+

--- a/src/images/icons/cross.svg
+++ b/src/images/icons/cross.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<g stroke="inherit" stroke-width="2.5" stroke-miterlimit="10">
+	<line x1="2.2" y1="2.3" x2="29.8" y2="29.8" fill="none"/>
+	<line x1="29.8" y1="2.3" x2="2.2" y2="29.8" fill="none"/>
+</g>
+</svg>

--- a/src/images/icons/plus.svg
+++ b/src/images/icons/plus.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<g stroke="inherit" stroke-width="2.5" stroke-miterlimit="10">
+	<line class="st0" x1="4.2" y1="16" x2="27.8" y2="16" fill="none"/>
+	<line class="st0" x1="16" y1="4.2" x2="16" y2="27.8" fill="none"/>
+</g>
+</svg>

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -8,8 +8,12 @@
                     @select-studies="selectStudies($event)"
                 />
             </div>
-            <div class="no-study" v-else-if="loading === false">
+            <div class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 no-study" v-else-if="loading === false">
                 No study is selected
+                <AddStudiesButton
+                    :currentStudySelection="studies.map(study => study.id)"
+                    @select-studies="selectStudies($event)"
+                />
             </div>
         </div>  
     </Skeleton>
@@ -55,11 +59,12 @@ function selectStudies(studyIds) {
 }
 .no-study {
     display:flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
     justify-content: center;
     padding: 64px 16px;
-    margin-bottom: 32px;
     background-color: #ededed;
     border-radius: 8px;
-    width: 100%;
 }
 </style>

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -5,6 +5,7 @@
             <StudiesComparison
                 v-if="studies.length > 0"
                 :studies="studies"
+                @select-studies="selectStudies($event)"
             />
             <div class="no-study" v-else-if="loading === false">
                 No study is selected
@@ -15,13 +16,14 @@
 
 <script setup>
 import Skeleton from '@components/Skeleton.vue';
-import { watch, ref } from 'vue';
-import { useRoute } from 'vue-router'
+import { watch, ref, } from 'vue';
+import { useRoute, useRouter } from 'vue-router'
 import { getStudyData } from '@utils/data';
 import StudiesComparison from '../components/StudiesComparison.vue';
-import { extractStudiesFromQueryString } from '@utils/router';
+import { extractStudiesFromQueryString, getStudyListQueryString } from '@utils/router';
 
 const route = useRoute();
+const router = useRouter();
 
 const loading = ref(false);
 const studies = ref([])
@@ -35,7 +37,11 @@ watch(route, async () => {
     loading.value = true;
     studies.value = await Promise.all(studyIds.map(getStudyData))
     loading.value = false;
-}, { immediate: true })
+}, { immediate: true });
+
+function selectStudies(studyIds) {
+    router.replace({ query: { studies: getStudyListQueryString(studyIds) } });
+}
 
 </script>
 

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -1,12 +1,13 @@
 <template>
     <Skeleton>
-        <div class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 max-w-[90%] lg:w-[80%]">
-            <h1>Compare VCA4D Value chain studies</h1>
-            <StudiesComparison
-                v-if="studies.length > 0"
-                :studies="studies"
-                @select-studies="selectStudies($event)"
-            />
+        <div>
+            <h1 class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48">Compare VCA4D Value chain studies</h1>
+            <div class="py-1 pb-16 px-4 sm:px-8 md:px-12 lg:px-40 xl:px-48 studies-wrapper" v-if="studies.length > 0">
+                <StudiesComparison
+                    :studies="studies"
+                    @select-studies="selectStudies($event)"
+                />
+            </div>
             <div class="no-study" v-else-if="loading === false">
                 No study is selected
             </div>
@@ -46,6 +47,12 @@ function selectStudies(studyIds) {
 </script>
 
 <style scoped lang="scss">
+.studies-wrapper {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+    overflow-y: scroll;
+}
 .no-study {
     display:flex;
     justify-content: center;


### PR DESCRIPTION
## Contexte

#38 

On crée une page de comaraison où on peut modifier la selection des études à comparer

On ajoute donc

- Un bouton pour supprimer des études de la comparaison
- Un bouton pour selectionner plus d'études

<details><summary>Screenshot</summary>

  [Screencast from 2024-07-26 09-36-27.webm](https://github.com/user-attachments/assets/0c49c38b-a80a-42b9-b1a8-ea971e10c86e)

</details>

## Changement

- Qques fix opportunistes
- Ajout du bouton "remove" qui update `route.query.studies`
- Ajout du bouton `Add studies` qui ouvre une modal avec un tableau
  - Ajout du bouton dans une nouvelle colonne du tableau (J'ai essayer en le mettant en dehors du `table`, et j'y ai passé ma journée :sob:)
  - Ajout d'un composant Modal simple
  - Ajout du composant de tableau selecteur d'études (:construction: à affiner visuellement a la prochaine PR)
- Integration du flow d'ajout.
- :black_flag: Desactivation de ces boutons en attendant la version finale du tableau selecteur

