### PR TITLE
refactor(38): Generify TableauDeDonnées

### DIFF
--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -32,61 +32,63 @@ const emit = defineEmits(["select-studies"]);
 
 </script>
 
-<style lang="scss">
-td {
-    box-sizing: border-box;
-}
-td {
-    @apply w-1/5
-}
-td.title {
-    @apply uppercase text-[#8A8A8A] font-bold text-sm pb-4;
-}
-td:first-child {
-    min-width: 220px;
-    padding-right: 20px;
-}
-.definition {
-    @apply text-[#9B9B9B] italic
-}
+<style lang="scss" scoped>
+:deep(*) {
+    td {
+        box-sizing: border-box;
+    }
+    td {
+        @apply w-1/5
+    }
+    td.title {
+        @apply uppercase text-[#8A8A8A] font-bold text-sm pb-4;
+    }
+    td:first-child {
+        min-width: 220px;
+        padding-right: 20px;
+    }
+    .definition {
+        @apply text-[#9B9B9B] italic
+    }
 
-.light-blue {
-    @apply bg-blue-200
-}
-.mid-blue {
-    @apply bg-blue-400
-}
-.dark-blue {
-    @apply bg-blue-500
-}
-.gray {
-    @apply bg-gray-300 text-gray-500
-}
-.light-green {
-    @apply bg-green-200
-}
-.dark-green {
-    @apply bg-green-700
-}
-.light-red {
-    @apply bg-red-300
-}
-.dark-red {
-    @apply bg-red-700
-}
-.right-border {
+    .light-blue {
+        @apply bg-blue-200
+    }
+    .mid-blue {
+        @apply bg-blue-400
+    }
+    .dark-blue {
+        @apply bg-blue-500
+    }
+    .gray {
+        @apply bg-gray-300 text-gray-500
+    }
+    .light-green {
+        @apply bg-green-200
+    }
+    .dark-green {
+        @apply bg-green-700
+    }
+    .light-red {
+        @apply bg-red-300
+    }
+    .dark-red {
+        @apply bg-red-700
+    }
+    .right-border {
+        @apply border-r-2
+    }
+    tr td:not(:first-child):not(:last-child):not(:nth-last-child(2)) {
     @apply border-r-2
-}
-tr td:not(:first-child):not(:last-child):not(:nth-last-child(2)) {
-  @apply border-r-2
-}
-tr.rounded td:not(:first-child) div {
-  @apply text-center text-sm py-1.5
-}
-tr.rounded td:nth-child(2) div{
-    @apply rounded-l-full
-}
-tr.rounded td:nth-last-child(2) div {
-    @apply rounded-r-full
+    }
+    tr.rounded td:not(:first-child) div {
+    @apply text-center text-sm py-1.5
+    }
+    tr.rounded td:nth-child(2) div{
+        @apply rounded-l-full
+    }
+    tr.rounded td:nth-last-child(2) div {
+        @apply rounded-r-full
+    }
 }
 </style>

--- a/src/components/StudyInclusiveness.vue
+++ b/src/components/StudyInclusiveness.vue
@@ -54,7 +54,12 @@
             class="mb-4 mt-8"
         />
         <div>
-            <ShareOfFarmPrice v-if="hasPricesData" :data="pricesData"/>
+            <ShareOfFarmPrice
+              v-if="hasPricesData"
+              :studyData="studyData"
+              :currency="currency"
+              :data="props.studyData.ecoData.farmToFinalPricesRatio"
+            />
             <NoDataBadge v-else/>
         </div>
         <br />
@@ -83,7 +88,6 @@ import ShareOfFarmPrice from './study/inclusiveness/ShareOfFarmPrice.vue'
 import NoDataBadge from '@components/study/NoDataBadge.vue';
 import QuestionTitle from "@components/study/QuestionTitle.vue"
 import { computed } from 'vue'
-import { useCurrencyUtils } from '@utils/format'
 import { LOCAL_STORAGE_ID } from '@utils/data'
 
 
@@ -92,7 +96,6 @@ const props = defineProps({
     currency: String
 })
 
-const { prettyAmount, convertAmount } = useCurrencyUtils(props);
 
 const hasPricesData = computed(() => {
     if (!props.studyData.ecoData.farmToFinalPricesRatio) {
@@ -102,21 +105,6 @@ const hasPricesData = computed(() => {
 })
 const isLocalStudy = computed(() => {
     return studyId === LOCAL_STORAGE_ID;
-})
-
-
-const pricesData = computed(() => {
-    if (!hasPricesData.value) {
-        return null
-    }
-    return props.studyData.ecoData.farmToFinalPricesRatio.map(item => ({
-        label: item.label,
-        farmProduct: item.farmProduct,
-        endProducts: item.endProducts,
-        farm: prettyAmount.value(convertAmount.value(item.farmPrice)),
-        final: prettyAmount.value(convertAmount.value(item.endPrice)),
-        ratio: item.farmPrice / item.endPrice
-    }))
 })
 
 </script>

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -6,7 +6,9 @@
       :rows="props.rows"
       :total="props.rows.length"
       :sortable="true"
-      :is-hide-paging="props.rows.length <= 10"
+      :max-height="maxHeight"
+      :pageSize="pageSize"
+      :is-hide-paging="props.rows.length <= pageSize"
       @row-clicked="onClickRow"
     >
       <template v-if="selectable" v-slot:checkbox="{ value: rowData }">
@@ -29,6 +31,15 @@
     selectedIds: {
       type: Array,
       default: []
+    },
+    pageSize: { 
+      type: Number,
+      default: 10,
+      validator: (size) => [10, 25, 50].includes(size)
+    },
+    maxHeight: {
+      type: Number,
+      required: false
     },
     rows: Array,
     columns: Array

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="width: 100%">
+  <div style="width: 100%" :class="{ selectable }">
     <TableLite
       :is-slot-mode="true"
       :columns="columnsWithCheckbox"
@@ -114,3 +114,62 @@
     return newSortedRows;
   }
 </script>
+
+<style scoped lang="scss">
+:deep(table) {
+
+  td, th {
+    color: #303030 !important;
+    background-color: white !important;
+    border-right: none !important;
+    border-left: none !important;
+    border-bottom: none !important;
+  }
+  td {
+    padding: 2px 4px 4px !important;
+  }
+
+  thead {
+    border-collapse: separate !important;
+    th {
+      border-top: none !important;
+      padding: 2px 4px 20px !important;
+
+      .vtl-sortable {
+        background-size: auto;
+        background-position: bottom right;
+        filter: hue-rotate(-20deg) saturate(2);
+      }
+
+    }
+  }
+  
+  tbody {
+    tr:first-child td {
+      border-top: none !important;
+    }
+  
+    td {
+      padding: 2px 4px 4px !important;
+    }
+  }
+}
+
+.selectable :deep(table) {
+  tr:hover {
+    td {
+      color: #3F83F8 !important;
+    }
+  }
+
+  td {
+    user-select: none;
+    cursor: pointer;
+
+    input {
+      accent-color: #3F83F8;
+      cursor: pointer;
+    }
+  }
+}
+</style>

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -2,12 +2,11 @@
   <div style="width: 100%">
     <TableLite
       :is-static-mode="true"
-      :columns="tableContent.columns"
-      :rows="tableContent.rows"
-      :total="tableContent.totalRecordCount"
-      :sortable="table.sortable"
-      :messages="table.messages"
-      :is-hide-paging="tableContent.totalRecordCount <= 10"
+      :columns="columns"
+      :rows="props.rows"
+      :total="props.rows.length"
+      :sortable="true"
+      :is-hide-paging="props.rows.length <= 10"
     >
     </TableLite>
   </div>
@@ -18,28 +17,7 @@
   import TableLite from "vue3-table-lite";
 
   const props = defineProps({
-    rows: Array
-  });
-  const table = ref({
-    isLoading: false,
-    sortable: {
-      order: "id",
-      sort: "asc",
-    },
-  });
-
-  const tableContent = computed(() => {
-    var columns = Object.keys(props.rows[0]).map((property) => {
-      return {
-        label: property,
-        field: property,
-        sortable: true,
-      };
-    });
-    return {
-      columns,
-      rows: props.rows,
-      totalRecordCount: props.rows.length,
-    };
+    rows: Array,
+    columns: Array
   });
 </script>

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -1,23 +1,68 @@
 <template>
   <div style="width: 100%">
     <TableLite
-      :is-static-mode="true"
-      :columns="columns"
+      :is-slot-mode="true"
+      :columns="columnsWithCheckbox"
       :rows="props.rows"
       :total="props.rows.length"
       :sortable="true"
       :is-hide-paging="props.rows.length <= 10"
+      @row-clicked="onClickRow"
     >
+      <template v-if="selectable" v-slot:checkbox="{ value: rowData }">
+        <input
+          type="checkbox"
+          :checked="isSelected(rowData.id)"
+          @click.stop="toggleRowSelection(rowData.id)"
+        />
+      </template>
     </TableLite>
   </div>
 </template>
 
 <script setup>
-  import { ref, computed } from "vue";
+  import { computed } from "vue";
   import TableLite from "vue3-table-lite";
 
   const props = defineProps({
+    selectable: Boolean,
+    selectedIds: {
+      type: Array,
+      default: []
+    },
     rows: Array,
     columns: Array
   });
+
+  const emits = defineEmits(["update:selectedIds"]);
+
+  function isSelected(rowId) {
+    return props.selectedIds.includes(rowId);
+  }
+
+  function onClickRow(rowData) {
+    if (! props.selectable) { return; }
+    return toggleRowSelection(rowData.id)
+  }
+
+  function toggleRowSelection(rowId) {
+    let newSelectedIds = [...props.selectedIds];
+
+    if (props.selectedIds.includes(rowId)) {
+      newSelectedIds = newSelectedIds.filter(id => id !== rowId);
+    } else {
+      newSelectedIds.push(rowId)
+    }
+
+    emits("update:selectedIds", newSelectedIds);
+  }
+
+  const columnsWithCheckbox = computed(() => {
+    if (! props.selectable) { return props.columns; }
+
+    return [
+      { field: "checkbox" },
+      ...props.columns
+    ];
+  })
 </script>

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -18,7 +18,7 @@
   import TableLite from "vue3-table-lite";
 
   const props = defineProps({
-    données: Array
+    rows: Array
   });
   const table = ref({
     isLoading: false,
@@ -29,7 +29,7 @@
   });
 
   const tableContent = computed(() => {
-    var columns = Object.keys(props.données[0]).map((property) => {
+    var columns = Object.keys(props.rows[0]).map((property) => {
       return {
         label: property,
         field: property,
@@ -38,8 +38,8 @@
     });
     return {
       columns,
-      rows: props.données,
-      totalRecordCount: props.données.length,
+      rows: props.rows,
+      totalRecordCount: props.rows.length,
     };
   });
 </script>

--- a/src/components/charts/TableauDeDonnées.vue
+++ b/src/components/charts/TableauDeDonnées.vue
@@ -2,55 +2,44 @@
   <div style="width: 100%">
     <TableLite
       :is-static-mode="true"
-      :is-loading="table.isLoading"
       :columns="tableContent.columns"
       :rows="tableContent.rows"
       :total="tableContent.totalRecordCount"
       :sortable="table.sortable"
       :messages="table.messages"
       :is-hide-paging="tableContent.totalRecordCount <= 10"
-      @is-finished="table.isLoading = false"
     >
     </TableLite>
   </div>
 </template>
 
-<script>
-import TableLite from "vue3-table-lite";
+<script setup>
+  import { ref, computed } from "vue";
+  import TableLite from "vue3-table-lite";
 
-export default {
-  components: {
-    TableLite,
-  },
-  props: {
-    données: Array,
-  },
-  data() {
-    return {
-      table: {
-        isLoading: false,
-        sortable: {
-          order: "id",
-          sort: "asc",
-        },
-      },
-    };
-  },
-  computed: {
-    tableContent() {
-      var columns = Object.keys(this.données[0]).map((property) => {
-        return {
-          label: property,
-          field: property,
-          sortable: true,
-        };
-      });
-      return {
-        columns,
-        rows: this.données,
-        totalRecordCount: this.données.length,
-      };
+  const props = defineProps({
+    données: Array
+  });
+  const table = ref({
+    isLoading: false,
+    sortable: {
+      order: "id",
+      sort: "asc",
     },
-  },
-};
+  });
+
+  const tableContent = computed(() => {
+    var columns = Object.keys(props.données[0]).map((property) => {
+      return {
+        label: property,
+        field: property,
+        sortable: true,
+      };
+    });
+    return {
+      columns,
+      rows: props.données,
+      totalRecordCount: props.données.length,
+    };
+  });
 </script>

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -13,7 +13,7 @@
                             <LogoProductLarge :product-name="study.product.id"/>
                         </template>
                     </Card>
-                    <a v-if="IS_COMPARISON_V2_ACTIVATED" class="remove-button" @click="removeStudy(study.id)">
+                    <a class="remove-button" @click="removeStudy(study.id)">
                         <Svg :svg="CrossLogo"/>
                     </a>
                 </div>
@@ -28,7 +28,6 @@
         </td>
         <td class="add-studies">
             <AddStudiesButton
-                v-if="IS_COMPARISON_V2_ACTIVATED"
                 :currentStudySelection="studiesWithDetails.map(study => study.id)"
                 @select-studies="emits('select-studies', $event)"
             />
@@ -50,7 +49,6 @@ import Svg from '@components/Svg.vue';
 import AddStudiesButton from '@components/comparison/AddStudiesButton.vue';
 import CrossLogo from '../../images/icons/cross.svg'
 
-const IS_COMPARISON_V2_ACTIVATED = false;
 const props = defineProps({
     studies: Array,
 })

--- a/src/components/comparison/StudiesListTable.vue
+++ b/src/components/comparison/StudiesListTable.vue
@@ -32,31 +32,47 @@
 
     async function loadStudyData() {
       const jsonStudies = getAllJsonData().studies;
-      return Promise.all(jsonStudies.map(({ id }) => getStudyData(id)))
+      return Promise.all(jsonStudies.map(({ id }) => populateStudy(id)))
     }
   });
+  async function populateStudy(id) {
+    const studyData = await getStudyData(id);
+    return {
+      id: studyData.id,
+      product: _.capitalize(getProduct(getStudy(studyData.id).product).prettyName),
+      country: _.capitalize(getCountry(getStudy(studyData.id).country).prettyName),
+      isEcoAvailable: isAvailable(studyData, "ecoData"),
+      isSocialAvailable: isAvailable(studyData, "socialData"),
+      isAcvAvailable: isAvailable(studyData, "acvData")
+    }
+  }
 
   const emits = defineEmits(["select-studies"]);
 
   const columns = [{
     label: "Product",
-    display: (studyData) => _.capitalize(getProduct(getStudy(studyData.id).product).prettyName)
+    field: "product",
+    sortable: true
   }, {
     label: "Country",
-    display:(studyData) => _.capitalize(getCountry(getStudy(studyData.id).country).prettyName)
+    field: "country",
+    sortable: true
   }, {
     label: "Macro economic indicators",
-    display: buildAvailibilityDisplay("ecoData")
+    field: "isEcoAvailable",
+    sortable: true
   }, {
     label: "Social sustainability",
-    display: buildAvailibilityDisplay("socialData")
+    field: "isSocialAvailable",
+    sortable: true
   }, {
     label: "Environmental analysis",
-    display: buildAvailibilityDisplay("acvData")
+    field: "isAcvAvailable",
+    sortable: true
   }];
 
-  function buildAvailibilityDisplay(dataKey) {
-    return (studyData) => !! studyData[dataKey] ? "Available" : "-"
+  function isAvailable(studyData, dataKey) {
+    return !! studyData[dataKey] ? "Available" : "-"
   }
 </script>
 

--- a/src/components/comparison/StudiesListTable.vue
+++ b/src/components/comparison/StudiesListTable.vue
@@ -1,24 +1,14 @@
 <template>
-  <TableLite
-    :is-slot-mode="true"
+  <DataTable
     class="table"
-    :isLoading="studies.length === 0"
-    :columns="columns"
-    :max-height="500"
-    :total="studies.length"
+    selectable
+    :selectedIds="newSelectedStudies"
+    :maxHeight="500"
+    :pageSize="50"
     :rows="studies"
-    :page-size="50"
-    :is-hide-paging="studies.length <= 50"
-    @row-clicked="(rowData) => toggleRowSelection(rowData.id)"
-  >
-    <template v-slot:checkbox="{ value: studyData }">
-      <input
-        type="checkbox"
-        :checked="isSelected(studyData.id)"
-        @click.stop="toggleRowSelection(studyData.id)"
-      />
-    </template>
-  </TableLite>
+    :columns="columns"
+    @update:selectedIds="newSelectedStudies = $event"
+  />
   <div class="footer">
     <button class="confirm-button" @click="emits('select-studies', newSelectedStudies)">Show comparison</button>
   </div>
@@ -26,8 +16,8 @@
 
 <script setup>
   import _ from "lodash";
-  import { onMounted, ref, computed } from 'vue';
-  import TableLite from 'vue3-table-lite';
+  import DataTable from "@components/charts/DataTable.vue";
+  import { onMounted, ref } from 'vue';
   import { getAllJsonData, getStudy, getStudyData, getProduct, getCountry } from '@utils/data';
 
   const props = defineProps({
@@ -46,22 +36,9 @@
     }
   });
 
-  function isSelected(studyId) {
-    return newSelectedStudies.value.includes(studyId);
-  }
-  function toggleRowSelection(studyId) {
-    if (newSelectedStudies.value.includes(studyId)) {
-      newSelectedStudies.value = newSelectedStudies.value.filter(id => id !== studyId);
-    } else {
-      newSelectedStudies.value.push(studyId)
-    }
-  }
-
   const emits = defineEmits(["select-studies"]);
 
   const columns = [{
-    field: "checkbox"
-  }, {
     label: "Product",
     display: (studyData) => _.capitalize(getProduct(getStudy(studyData.id).product).prettyName)
   }, {

--- a/src/components/study/inclusiveness/ShareOfFarmPrice.vue
+++ b/src/components/study/inclusiveness/ShareOfFarmPrice.vue
@@ -1,13 +1,13 @@
 <template >
   <div>
     <DataTable
-      :rows="tableRows"
+      :rows="props.data"
+      :columns=columns
     />
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
 
 import DataTable from "@components/charts/DataTable.vue";
 import { formatPercent } from '@utils/format.js'
@@ -15,18 +15,32 @@ const props = defineProps({
     data: Array,
 })
 
-const tableRows = computed(() => {
-  return props.data.map(item => {
-    return {
-      "Case": item.label,
-      "Farm product": item.farmProduct,
-      "Farm gate price": `${item.farm} per kg`,
-      "End products": item.endProducts,
-      "End products unit value": `${item.final} per kg`,
-      "Farm value part": formatPercent(item.ratio),
-    }
-  })
-})
+const columns = [{
+    label: "Case",
+    field: "label",
+    sortable: true,
+  }, {
+    label: "Farm product",
+    field: "farmProduct",
+    sortable: true,
+  }, {
+    label: "Farm gate price",
+    display: item => `${item.farm} per kg`,
+    sortable: true,
+  }, {
+    label: "End products",
+    field: "endProducts",
+    sortable: true,
+  }, {
+    label: "End products unit value",
+    display: item => `${item.final} per kg`,
+    sortable: true,
+  }, {
+    label: "Farm value part",
+    display: item => formatPercent(item.ratio),
+    sortable: true,
+  }
+]
 </script>
 
 <style>

--- a/src/components/study/inclusiveness/ShareOfFarmPrice.vue
+++ b/src/components/study/inclusiveness/ShareOfFarmPrice.vue
@@ -1,21 +1,21 @@
 <template >
   <div>
-    <TableauDeDonnées
-            :données="donnéesPourLeTableau"
-          />
+    <DataTable
+      :rows="tableRows"
+    />
   </div>
 </template>
 
 <script setup>
 import { computed } from 'vue'
 
-import TableauDeDonnées from "@components/charts/TableauDeDonnées.vue";
+import DataTable from "@components/charts/DataTable.vue";
 import { formatPercent } from '@utils/format.js'
 const props = defineProps({
     data: Array,
 })
 
-const donnéesPourLeTableau = computed(() => {
+const tableRows = computed(() => {
   return props.data.map(item => {
     return {
       "Case": item.label,

--- a/src/components/study/inclusiveness/ShareOfFarmPrice.vue
+++ b/src/components/study/inclusiveness/ShareOfFarmPrice.vue
@@ -1,5 +1,5 @@
 <template >
-  <div>
+  <div class="mt-8">
     <DataTable
       :rows="rowsWithRatio"
       :columns=columns

--- a/src/components/study/inclusiveness/ShareOfFarmPrice.vue
+++ b/src/components/study/inclusiveness/ShareOfFarmPrice.vue
@@ -1,7 +1,7 @@
 <template >
   <div>
     <DataTable
-      :rows="props.data"
+      :rows="rowsWithRatio"
       :columns=columns
     />
   </div>
@@ -11,8 +11,22 @@
 
 import DataTable from "@components/charts/DataTable.vue";
 import { formatPercent } from '@utils/format.js'
+import { computed } from "vue";
+import { useCurrencyUtils } from '@utils/format';
+
 const props = defineProps({
     data: Array,
+    currency: String,
+    studyData: Object
+})
+
+const { prettyAmount, convertAmount } = useCurrencyUtils(props);
+
+const rowsWithRatio = computed(() => {
+  return props.data.map(item => ({
+    ...item,
+    ratio: item.farmPrice / item.endPrice
+  }))
 })
 
 const columns = [{
@@ -25,7 +39,8 @@ const columns = [{
     sortable: true,
   }, {
     label: "Farm gate price",
-    display: item => `${item.farm} per kg`,
+    field: "farmPrice",
+    display: (item) => `${prettyAmount.value(convertAmount.value(item.farmPrice))} per kg`,
     sortable: true,
   }, {
     label: "End products",
@@ -33,10 +48,12 @@ const columns = [{
     sortable: true,
   }, {
     label: "End products unit value",
-    display: item => `${item.final} per kg`,
+    field: "endPrice",
+    display: (item) => `${prettyAmount.value(convertAmount.value(item.endPrice))} per kg`,
     sortable: true,
   }, {
     label: "Farm value part",
+    field: "ratio",
     display: item => formatPercent(item.ratio),
     sortable: true,
   }

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -1,22 +1,23 @@
 <template>
-    <Skeleton>
-        <div>
-            <h1 class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48">Compare VCA4D Value chain studies</h1>
-            <div class="py-1 pb-16 px-4 sm:px-8 md:px-12 lg:px-40 xl:px-48 studies-wrapper" v-if="studies.length > 0">
-                <StudiesComparison
-                    :studies="studies"
-                    @select-studies="selectStudies($event)"
-                />
-            </div>
-            <div class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 no-study" v-else-if="loading === false">
-                No study is selected
-                <AddStudiesButton
-                    :currentStudySelection="studies.map(study => study.id)"
-                    @select-studies="selectStudies($event)"
-                />
-            </div>
-        </div>  
-    </Skeleton>
+  <Skeleton>
+    <div>
+      <h1 class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48">Compare VCA4D Value chain studies</h1>
+      <div class="py-1 pb-16 px-4 sm:px-8 md:px-12 lg:px-40 xl:px-48 studies-wrapper" v-if="studies.length > 0">
+        <StudiesComparison
+          :studies="studies"
+          @select-studies="selectStudies($event)"
+        />
+      </div>
+      <div class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 no-study" v-else-if="loading === false">
+        No study is selected
+        <AddStudiesButton
+          class="mt-4"
+          :currentStudySelection="studies.map(study => study.id)"
+          @select-studies="selectStudies($event)"
+        />
+      </div>
+    </div>  
+  </Skeleton>
 </template>
 
 <script setup>
@@ -25,6 +26,7 @@ import { watch, ref, } from 'vue';
 import { useRoute, useRouter } from 'vue-router'
 import { getStudyData } from '@utils/data';
 import StudiesComparison from '../components/StudiesComparison.vue';
+import AddStudiesButton from "@components/comparison/AddStudiesButton.vue";
 import { extractStudiesFromQueryString, getStudyListQueryString } from '@utils/router';
 
 const route = useRoute();


### PR DESCRIPTION
# Contexte

Dans #38, j'ajoute un tableau dans la page de comparaison. Hors, il en existe déjà un dans la page d'Inclusiveness, codé avec le générique `TableaDeDonnées`.

Cette PR refactor ce composant pour l'adapter aux 2 use case

## Changements

- Composition API + Anglais
- Utilisation du slot-mode, car `hasCheckbox` ne permet pas d'avoir des rows deja selected
- Modification de l'interface du composant pour données toute la largeur d'actions aux utilisateurs du composant
- Utilisation de `doSearch` pour trier les données. Le sort "natif" ne marchant pas avec le slot-mode

### :warning: Pour la review fonctionnelle sur la branche, ne pas oublier d'activer le flag dans ComparisonHeader