### PR TITLE
feat: Update table style

### DIFF
--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -32,61 +32,63 @@ const emit = defineEmits(["select-studies"]);
 
 </script>
 
-<style lang="scss">
-td {
-    box-sizing: border-box;
-}
-td {
-    @apply w-1/5
-}
-td.title {
-    @apply uppercase text-[#8A8A8A] font-bold text-sm pb-4;
-}
-td:first-child {
-    min-width: 220px;
-    padding-right: 20px;
-}
-.definition {
-    @apply text-[#9B9B9B] italic
-}
+<style lang="scss" scoped>
+:deep(*) {
+    td {
+        box-sizing: border-box;
+    }
+    td {
+        @apply w-1/5
+    }
+    td.title {
+        @apply uppercase text-[#8A8A8A] font-bold text-sm pb-4;
+    }
+    td:first-child {
+        min-width: 220px;
+        padding-right: 20px;
+    }
+    .definition {
+        @apply text-[#9B9B9B] italic
+    }
 
-.light-blue {
-    @apply bg-blue-200
-}
-.mid-blue {
-    @apply bg-blue-400
-}
-.dark-blue {
-    @apply bg-blue-500
-}
-.gray {
-    @apply bg-gray-300 text-gray-500
-}
-.light-green {
-    @apply bg-green-200
-}
-.dark-green {
-    @apply bg-green-700
-}
-.light-red {
-    @apply bg-red-300
-}
-.dark-red {
-    @apply bg-red-700
-}
-.right-border {
+    .light-blue {
+        @apply bg-blue-200
+    }
+    .mid-blue {
+        @apply bg-blue-400
+    }
+    .dark-blue {
+        @apply bg-blue-500
+    }
+    .gray {
+        @apply bg-gray-300 text-gray-500
+    }
+    .light-green {
+        @apply bg-green-200
+    }
+    .dark-green {
+        @apply bg-green-700
+    }
+    .light-red {
+        @apply bg-red-300
+    }
+    .dark-red {
+        @apply bg-red-700
+    }
+    .right-border {
+        @apply border-r-2
+    }
+    tr td:not(:first-child):not(:last-child):not(:nth-last-child(2)) {
     @apply border-r-2
-}
-tr td:not(:first-child):not(:last-child):not(:nth-last-child(2)) {
-  @apply border-r-2
-}
-tr.rounded td:not(:first-child) div {
-  @apply text-center text-sm py-1.5
-}
-tr.rounded td:nth-child(2) div{
-    @apply rounded-l-full
-}
-tr.rounded td:nth-last-child(2) div {
-    @apply rounded-r-full
+    }
+    tr.rounded td:not(:first-child) div {
+    @apply text-center text-sm py-1.5
+    }
+    tr.rounded td:nth-child(2) div{
+        @apply rounded-l-full
+    }
+    tr.rounded td:nth-last-child(2) div {
+        @apply rounded-r-full
+    }
 }
 </style>

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -114,3 +114,14 @@
     return newSortedRows;
   }
 </script>
+
+<style scoped lang="scss">
+:deep(table) {
+  thead {
+    .vtl-sortable {
+      background-size: auto;
+      background-position: bottom right;
+    }
+  }
+}
+</style>

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="width: 100%">
+  <div style="width: 100%" :class="{ selectable }">
     <TableLite
       :is-slot-mode="true"
       :columns="columnsWithCheckbox"
@@ -151,6 +151,24 @@
   
     td {
       padding: 2px 4px 4px !important;
+    }
+  }
+}
+
+.selectable :deep(table) {
+  tr:hover {
+    td {
+      color: #3F83F8 !important;
+    }
+  }
+
+  td {
+    user-select: none;
+    cursor: pointer;
+
+    input {
+      accent-color: #3F83F8;
+      cursor: pointer;
     }
   }
 }

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -117,10 +117,40 @@
 
 <style scoped lang="scss">
 :deep(table) {
+
+  td, th {
+    color: #303030 !important;
+    background-color: white !important;
+    border-right: none !important;
+    border-left: none !important;
+    border-bottom: none !important;
+  }
+  td {
+    padding: 2px 4px 4px !important;
+  }
+
   thead {
-    .vtl-sortable {
-      background-size: auto;
-      background-position: bottom right;
+    border-collapse: separate !important;
+    th {
+      border-top: none !important;
+      padding: 2px 4px 20px !important;
+
+      .vtl-sortable {
+        background-size: auto;
+        background-position: bottom right;
+        filter: hue-rotate(-20deg) saturate(2);
+      }
+
+    }
+  }
+  
+  tbody {
+    tr:first-child td {
+      border-top: none !important;
+    }
+  
+    td {
+      padding: 2px 4px 4px !important;
     }
   }
 }

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -13,7 +13,7 @@
                             <LogoProductLarge :product-name="study.product.id"/>
                         </template>
                     </Card>
-                    <a v-if="IS_COMPARISON_V2_ACTIVATED" class="remove-button" @click="removeStudy(study.id)">
+                    <a class="remove-button" @click="removeStudy(study.id)">
                         <Svg :svg="CrossLogo"/>
                     </a>
                 </div>
@@ -28,7 +28,6 @@
         </td>
         <td class="add-studies">
             <AddStudiesButton
-                v-if="IS_COMPARISON_V2_ACTIVATED"
                 :currentStudySelection="studiesWithDetails.map(study => study.id)"
                 @select-studies="emits('select-studies', $event)"
             />
@@ -50,7 +49,6 @@ import Svg from '@components/Svg.vue';
 import AddStudiesButton from '@components/comparison/AddStudiesButton.vue';
 import CrossLogo from '../../images/icons/cross.svg'
 
-const IS_COMPARISON_V2_ACTIVATED = false;
 const props = defineProps({
     studies: Array,
 })

--- a/src/components/study/inclusiveness/ShareOfFarmPrice.vue
+++ b/src/components/study/inclusiveness/ShareOfFarmPrice.vue
@@ -1,5 +1,5 @@
 <template >
-  <div>
+  <div class="mt-8">
     <DataTable
       :rows="rowsWithRatio"
       :columns=columns

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -1,22 +1,23 @@
 <template>
-    <Skeleton>
-        <div>
-            <h1 class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48">Compare VCA4D Value chain studies</h1>
-            <div class="py-1 pb-16 px-4 sm:px-8 md:px-12 lg:px-40 xl:px-48 studies-wrapper" v-if="studies.length > 0">
-                <StudiesComparison
-                    :studies="studies"
-                    @select-studies="selectStudies($event)"
-                />
-            </div>
-            <div class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 no-study" v-else-if="loading === false">
-                No study is selected
-                <AddStudiesButton
-                    :currentStudySelection="studies.map(study => study.id)"
-                    @select-studies="selectStudies($event)"
-                />
-            </div>
-        </div>  
-    </Skeleton>
+  <Skeleton>
+    <div>
+      <h1 class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48">Compare VCA4D Value chain studies</h1>
+      <div class="py-1 pb-16 px-4 sm:px-8 md:px-12 lg:px-40 xl:px-48 studies-wrapper" v-if="studies.length > 0">
+        <StudiesComparison
+          :studies="studies"
+          @select-studies="selectStudies($event)"
+        />
+      </div>
+      <div class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 no-study" v-else-if="loading === false">
+        No study is selected
+        <AddStudiesButton
+          class="mt-4"
+          :currentStudySelection="studies.map(study => study.id)"
+          @select-studies="selectStudies($event)"
+        />
+      </div>
+    </div>  
+  </Skeleton>
 </template>
 
 <script setup>
@@ -25,6 +26,7 @@ import { watch, ref, } from 'vue';
 import { useRoute, useRouter } from 'vue-router'
 import { getStudyData } from '@utils/data';
 import StudiesComparison from '../components/StudiesComparison.vue';
+import AddStudiesButton from "@components/comparison/AddStudiesButton.vue";
 import { extractStudiesFromQueryString, getStudyListQueryString } from '@utils/router';
 
 const route = useRoute();


### PR DESCRIPTION
## Contexte

Après avoir générifié `DataTable` dans https://github.com/leonarf/VCA4D/pull/48, je modifie son style

| avant | après |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/e97dc59d-2eb8-4dc7-bb85-85a1c947bfae) | ![image](https://github.com/user-attachments/assets/79dbc3b6-88a3-4e43-8844-0582b4d636ce) |

Quelques différence notables avec le [Figma](https://www.figma.com/design/6mmWHxGGyAEAvgSUm5dGFD/VCA4D?node-id=623-1688&t=ibKIDdrVxdE8rYwt-4)

- Pas de texte "sort" sur le header, j'ai gardé les fleches de TableLite.
- Pas de blur bleu en dessous du tableau pour indiquer qu'on est pas en bas (ajouté à https://github.com/leonarf/VCA4D/issues/49)
- Scrollbar pas exactement bleue (mais de la couleur du browser) (ajouté à https://github.com/leonarf/VCA4D/issues/49)
- Addition en hover lorsqu'on select des rows (cf screenshot ci dessous)

<details><summary>Screenshot</summary>

[Screencast from 2024-07-29 18-59-57.webm](https://github.com/user-attachments/assets/3bdee86f-a5e0-4f4b-bc9d-42318ac53c7b)

</details>
 
 ### :warning: Cette PR est par dessus #48, je mergerais celle ci, puis #48