### PR TITLE
refacto de la gestion des couleurs + css mini graphiques

### DIFF
--- a/src/charts/charts.js
+++ b/src/charts/charts.js
@@ -1,5 +1,5 @@
 import { formatNumber, formatPercent } from '@utils/format.js'
-import { getStageColor, getRingColor, COLORS_IMPORTED_PRODUCTS, COLORS_EXPORTED_PRODUCTS } from '@utils/colors.js'
+import { getColor, getRingColor, COLORS_IMPORTED_PRODUCTS, COLORS_EXPORTED_PRODUCTS } from '@utils/colors.js'
 import { getStageLabel } from '../utils/stages'
 const RADIUSES_MINI_PIE = ['20%', '40%']
 const RIADUSES_PIE = ['50%', '75%']
@@ -32,7 +32,7 @@ export const getRingChart = (items, tooltip, title, isEnvironment = false) => {
                 radius: RIADUSES_PIE,
                 itemStyle: {
                     color: function (info) {
-                        return isEnvironment ? getRingColor(info.name) : getStageColor(info.name)
+                        return isEnvironment ? getRingColor(info.name) : getColor(info.name)
                     }
                 }
             }
@@ -207,9 +207,9 @@ export const getSelectableBarChart = (items, currentItem, tooltip, formatLabel, 
     let values = []
     items.map(item => {
         labels.push(item.name)
-        // const color = currentItem === item.name ? SELECTED_COLOR : getStageColor(item.name)
-        // const emphasisColor = currentItem === item.name ? SELECTED_COLOR_HOVER : getStageColor(item.name) + "B3"
-        const color = getStageColor(item.name, isEnvironment)
+        // const color = currentItem === item.name ? SELECTED_COLOR : getColor(item.name)
+        // const emphasisColor = currentItem === item.name ? SELECTED_COLOR_HOVER : getColor(item.name) + "B3"
+        const color = getColor(item.name, isEnvironment)
         const emphasisColor = color + "B3"
         values.push({
             value: item.value,
@@ -448,7 +448,17 @@ const getMiniBarChart = (items, tooltip, formatLabel) => {
     let values = []
     items.map(item => {
         labels.push(item.name)
-        values.push(item.value)
+        // code temporaire pour récupérer une couleur, il faudra récupérer la couleur du stage quand pertinent à l'avenir
+        const color = getColor(item.name)
+        const emphasisColor = color + "B3"
+        console.log("items", item)
+        values.push({
+            value: item.value,
+            emphasisColor,
+            itemStyle: {
+                color,
+            }
+        })
     })
     return {
         xAxis: {
@@ -457,7 +467,7 @@ const getMiniBarChart = (items, tooltip, formatLabel) => {
             axisLabel: {
                 fontSize: 15,
                 fontWeight: 500,
-                color: '#e2e0e0',
+                //color: '#e2e0e0',
                 interval: 0,
                 rotate: -10,
                 margin: 20
@@ -470,13 +480,13 @@ const getMiniBarChart = (items, tooltip, formatLabel) => {
                 if (!d.data) {
                     return ""
                 }
-                return formatLabel ? formatLabel(d.data) : formatNumber(d.data)
+                return formatLabel ? formatLabel(d.data.value) : formatNumber(d.data.value)
             },
             textStyle: {
                 fontSize: 22,
                 fontWeight: 500,
             },
-            color: '#e2e0e0'
+            //color: '#e2e0e0'
         },
         tooltip: {
             trigger: 'item',
@@ -576,7 +586,7 @@ const getMiniPieChart = (data, title, valueFormatter) => {
                 label: {
                     width: 120,
                     overflow: 'break',
-                    color: "#e2e0e0",
+                    //color: "#e2e0e0",
                     fontSize: 15
                 },
                 labelLine: {

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -1,5 +1,5 @@
 import { useCurrencyUtils } from '@utils/format.js'
-import { addColors } from '@utils/colors.js'
+import { getColor } from '@utils/colors.js'
 
 const getNodeGap = (studyData) => {
     // First we look at number of flows we have. We force it in the range [10, 40]
@@ -84,8 +84,7 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
         return ret
     })
 
-    sankeyStages = addColors(sankeyStages)
-
+    sankeyStages.forEach(item => {item.color = getColor(item.name)})
     // Attribute an index to each stage. If a stage with index N give a flow to another stage it will have index N + 1
     for (let idx = 0; idx < 15; idx++) {
         const stages = sankeyStages.filter(sStage => sStage.index === idx)

--- a/src/components/StudyEnvironment.vue
+++ b/src/components/StudyEnvironment.vue
@@ -9,7 +9,7 @@
     <p>
       First, damages entailed by the Value Chain operations are calculated on <strong>Resource depletion</strong>,
       <strong>Ecosystem quality</strong> and <strong>Human health</strong>, as well as their contribution
-      to <trong>Climate Change</trong> through the quantitative <strong>Life Cycle Assessment (LCA)</strong>.
+      to <strong>Climate Change</strong> through the quantitative <strong>Life Cycle Assessment (LCA)</strong>.
     </p>
     <p> 
       Second, an <strong>exploratory assessment of biodiversity risks is provided</strong>.

--- a/src/components/charts/MiniChartContainer.vue
+++ b/src/components/charts/MiniChartContainer.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue'
-import { getStageColor } from '@utils/colors.js'
+import { getColor } from '@utils/colors.js'
 
 const props = defineProps({
     currentStage: String,
@@ -12,17 +12,24 @@ const props = defineProps({
     }
 })
 
-const bgColor = computed(() => {
+const divStyle = computed(() => {
     return {
-        backgroundColor: getStageColor(props.currentStage, props.isEnvironment) 
+        border: "1rem solid",
+        borderColor: getColor(props.currentStage, props.isEnvironment),
+    }
+})
+
+const titleStyle = computed(() => {
+    return {
+        backgroundColor: getColor(props.currentStage, props.isEnvironment),
     }
 })
 </script>
 
 <template>
-    <div :style="bgColor" class="rounded-2xl px-12 py-12 w-full">
+    <div :style="divStyle" class="rounded-2xl px-12 py-12 w-full">
         <template v-if="currentStage !== ''">
-            <span class="text-[#e2e0e0] text-xl"><strong>{{ title }}</strong> in {{ currentStage }}</span>
+            <span :style="titleStyle" class="text-[#e2e0e0] text-xl"><strong>{{ title }}</strong> in {{ currentStage }}</span>
             <slot></slot>
         </template>
     </div>

--- a/src/components/study/social-sustainability/SocialDetailsGroup.vue
+++ b/src/components/study/social-sustainability/SocialDetailsGroup.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="social-details-group flex flex-row items-center rounded-3xl px-3 py-2 max-w-[650px] my-8 cursor-pointer"
         @click="isOpen = !isOpen"
-        :style="{ '--color': getTagColor(group.averageValue) + '81', '--color-hover': getTagColor(group.averageValue) }">
+        :style="{ '--color': getSocialScoreColor(group.averageValue) + '81', '--color-hover': getSocialScoreColor(group.averageValue) }">
         <div class="tag-number">{{ getNumberInTitle(group.title) }}
         </div>
         <div class="font-bold flex-grow">{{ removeNumberFromTitle(group.title) }}</div>
@@ -21,7 +21,7 @@
 <script setup>
 import { ref } from 'vue';
 import Tag from './Tag.vue'
-import { getTagColor } from '@utils/colors.js'
+import { getSocialScoreColor } from '@utils/colors.js'
 
 const props = defineProps({
     group: Object

--- a/src/components/study/social-sustainability/SocialRadar.vue
+++ b/src/components/study/social-sustainability/SocialRadar.vue
@@ -5,7 +5,7 @@
 <script setup>
 import { computed } from 'vue'
 import { getSocialAverageGroup } from '@utils/misc.js'
-import { getTagColor } from '@utils/colors.js'
+import { getSocialScoreColor } from '@utils/colors.js'
 
 import Radar from '@charts/Radar.vue'
 const props = defineProps({
@@ -44,7 +44,7 @@ const chartData = computed(() => {
       splitNumber: 4,
       splitArea: {
         areaStyle: {
-          color: [getTagColor(1), getTagColor(2), getTagColor(3), getTagColor(4)]
+          color: [getSocialScoreColor(1), getSocialScoreColor(2), getSocialScoreColor(3), getSocialScoreColor(4)]
         }
       },
       axisLine: {

--- a/src/components/study/social-sustainability/SocialSummary.vue
+++ b/src/components/study/social-sustainability/SocialSummary.vue
@@ -19,10 +19,10 @@
     </p>
     <p>
       The four levels of social sustainability are illustrated by different colours in the chart:
-      <b :style="{ backgroundColor: getTagColor(4) }">high (green)</b>,
-      <b :style="{ backgroundColor: getTagColor(3) }">substantial (yellow)</b>,
-      <b :style="{ backgroundColor: getTagColor(2) }">moderate/low (orange)</b>,
-      <b :style="{ backgroundColor: getTagColor(1) }">not at all (red)</b>.
+      <b :style="{ backgroundColor: getSocialScoreColor(4) }">high (green)</b>,
+      <b :style="{ backgroundColor: getSocialScoreColor(3) }">substantial (yellow)</b>,
+      <b :style="{ backgroundColor: getSocialScoreColor(2) }">moderate/low (orange)</b>,
+      <b :style="{ backgroundColor: getSocialScoreColor(1) }">not at all (red)</b>.
     </p>
     <div class="grid grid-cols-3 w-full gap-2">
       <div class="row-span-2 self-start xl:self-end">
@@ -100,7 +100,7 @@ import SocialRadar from './SocialRadar.vue'
 import SummaryBlock from './SummaryBlock.vue'
 import SummaryBlockQuestion from './SummaryBlockQuestion.vue'
 import { getSocialAverageGroup } from '@utils/misc.js'
-import { getTagColor } from '@utils/colors.js'
+import { getSocialScoreColor } from '@utils/colors.js'
 
 const props = defineProps({
   studyData: Object

--- a/src/components/study/social-sustainability/SummaryBlock.vue
+++ b/src/components/study/social-sustainability/SummaryBlock.vue
@@ -12,7 +12,7 @@
 
 <script setup>
 import { computed } from 'vue';
-import { getTagColor } from '@utils/colors.js'
+import { getSocialScoreColor } from '@utils/colors.js'
 const props = defineProps({
   title: String,
   anchor: Number,
@@ -30,7 +30,7 @@ const slideTo = (id) => {
 }
 
 const bgColor = computed(() => {
-    const color = getTagColor(props.averageValue)
+    const color = getSocialScoreColor(props.averageValue)
     return {
         backgroundColor: color ? color + '81' : '#f1f1f1'
     }

--- a/src/components/study/social-sustainability/Tag.vue
+++ b/src/components/study/social-sustainability/Tag.vue
@@ -5,14 +5,14 @@
 
 <script setup>
 import { computed } from 'vue';
-import { getTagColor } from '@utils/colors.js'
+import { getSocialScoreColor } from '@utils/colors.js'
 
 const props = defineProps({
   scale: Number,
   appreciation: String
 });
 
-const scaleColor = computed(() => getTagColor(props.scale))
+const scaleColor = computed(() => getSocialScoreColor(props.scale))
 
 </script>
 

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,51 +1,45 @@
-
-const ADDITIONAL_COLORS = ["#e5d08f", "#e3d4b6",
-  "#cacbce",
-  "#e1dfdf"]
-
-var StagesColors = {
-  Producers: "#6AAB9C",
-  Collectors: "#FA9284",
-  Processors: "#E06C78",
-  Wholesalers: "#5874DC",
-  Retailers: "#384E78",
-  Exporters: "#b57ba6",
-  landOwnersFees: ADDITIONAL_COLORS[0],
-  depreciation: ADDITIONAL_COLORS[1],
-  employeeWages:ADDITIONAL_COLORS[2],
-  financialInstitutionsInterests: ADDITIONAL_COLORS[3]
+const AVAILABLE_COLORS = {
+  StageProducerGreen : "#6AAB9C",
+  StageCollectorSalmon : "#FA9284",
+  StageProcessorRed : "#E06C78",
+  StageWholesalerBlue : "#5874DC",
+  StageRetailerDarkBlue : "#384E78",
+  Grey : "#CACBCE",
+  LightGrey : "E1DFDF",
+  Bronze : "#E5D08F",
+  LightBronze : "#E3D4B6",
+  BadScoreRed: "#ffac9e",
+  LowScoreOrange: "#fec875",
+  SubstantialScoreYellow: "#d7e275",
+  HighScoreGreen : "#94d99d",
 }
 
-var ChainValuesColors = {}
-
-export const addColorsForValueChains = (valuechains) => {
-  // TODO remplir ChainValuesColors avec de bonnes couleurs en utilisant une heuristique basée sur l'impact de la chaîne de valeur si possible
-  // Du genre + polluant = plus rouge
+var FixedColorsMapping = {
+  Producers: AVAILABLE_COLORS["StageProducerGreen"],
+  Collectors: AVAILABLE_COLORS["StageCollectorSalmon"],
+  Processors: AVAILABLE_COLORS["StageProcessorRed"],
+  Wholesalers: AVAILABLE_COLORS["StageWholesalerBlue"],
+  Retailers: AVAILABLE_COLORS["StageRetailerDarkBlue"],
+  landOwnersFees: AVAILABLE_COLORS["Bronze"],
+  depreciation: AVAILABLE_COLORS["LightBronze"],
+  employeeWages:AVAILABLE_COLORS["Grey"],
+  financialInstitutionsInterests: AVAILABLE_COLORS["LightGrey"]
 }
 
-export const getStageColor = (stageName, isEnvironment = false) => {
-  if (isEnvironment) {
-    return getSubChainColor(stageName)
-  }
-  if (stageName in StagesColors) {
-    return StagesColors[stageName]
-  }
-  if (stageName in ChainValuesColors) {
-    return ChainValuesColors[stageName]
-  }
-  var pickedColor = ADDITIONAL_COLORS[Object.keys(ChainValuesColors).length % ADDITIONAL_COLORS.length]
-  ChainValuesColors[stageName] = pickedColor
-  return ChainValuesColors[stageName]
-}
+var DynamicColorsMapping = {}
 
-const SUB_CHAIN_COLORS = [
-  "#6AAB9C",
-  "#FA9284",
-  "#E06C78",
-  "#5874DC",
-  "#384E78",
-  "#b57ba6",
-]
+export const getColor = (itemName) => {
+  if (itemName in FixedColorsMapping) {
+    return FixedColorsMapping[itemName]
+  }
+  if (itemName in DynamicColorsMapping) {
+    return DynamicColorsMapping[itemName]
+  }
+  var pickedColorName = Object.keys(AVAILABLE_COLORS)[Object.keys(DynamicColorsMapping).length % Object.keys(AVAILABLE_COLORS).length]
+  console.log("Dynamically added color to item", itemName, pickedColorName)
+  DynamicColorsMapping[itemName] = AVAILABLE_COLORS[pickedColorName]
+  return DynamicColorsMapping[itemName]
+}
 
 const RING_COLORS = [
   '#8B0000',
@@ -56,14 +50,6 @@ const RING_COLORS = [
   '#008080'
 ]
 
-let subChainsColors = {}
-const getSubChainColor = (subchainName) => {
-  if (!(subchainName in subChainsColors)) {
-    subChainsColors[subchainName] = SUB_CHAIN_COLORS[Object.keys(subChainsColors).length % SUB_CHAIN_COLORS.length]
-  }
-  return subChainsColors[subchainName]
-}
-
 let ringColors = {}
 export const getRingColor = (name) => {
   if (!(name in ringColors)) {
@@ -72,25 +58,20 @@ export const getRingColor = (name) => {
   return ringColors[name]
 } 
 
-export const addColors = (sankeyStages) => {
-  let ret = sankeyStages.map(sStage => (sStage.name in StagesColors) ? ({...sStage, color: StagesColors[sStage.name]}) : sStage)
-  
-  const stagesWithNoColors = ret.filter(sStage => !sStage.color)
-  stagesWithNoColors.map((stage, index) => {
-    const color = ADDITIONAL_COLORS[index % ADDITIONAL_COLORS.length]
-    ret = ret.map(sStage => sStage.name === stage.name ? {...sStage, color} : sStage)
-  })
-  return ret
+export const getSocialScoreColor = (value) => {
+  if (value < 1.5) {
+    return AVAILABLE_COLORS["BadScoreRed"]
+  }
+  else if (value < 2.5) {
+    return AVAILABLE_COLORS["LowScoreOrange"]
+  }
+  else if (value < 3.5) {
+    return AVAILABLE_COLORS["SubstantialScoreYellow"]
+  }
+  else {
+    return AVAILABLE_COLORS["HighScoreGreen"]
+  }
 }
-
-const tagsColors = [
-  "#ffac9e",
-  "#fec875",
-  "#d7e275",
-  "#94d99d",
-];
-
-export const getTagColor = (value) => tagsColors[Math.round(value) - 1]
 
 export const COLORS_IMPORTED_PRODUCTS = ['#5F8A64', '#71A578', '#9DB95F', '#C1CC5E']
 export const COLORS_EXPORTED_PRODUCTS = ['#b06245', '#C46D4D']


### PR DESCRIPTION
Première PR pour mieux gérer les couleurs des graphiques dans le code :
 - beaucoup de renommage
 - création d'un début de liste unique des couleurs, dans laquelle on pioche pour associé des couleur à des nouveaux éléments de graphique dynamiquement (les élément dont on ne connait pas le nom à l'avance parce qu'il dépend de l'étude)