### PR TITLE
feat: Add links to comparison pages from study header

### DIFF
--- a/src/components/study/ComparisonLink.vue
+++ b/src/components/study/ComparisonLink.vue
@@ -5,6 +5,8 @@
       name: 'comparison',
       query: { studies: getStudyListQueryString(otherStudies) }
     }"
+    :title="title"
+    target="_blank"
   >
     <Svg :svg="BalanceLogo" height="18px"/>
     {{ otherStudies.length }}
@@ -12,10 +14,11 @@
 </template>
 
 <script setup>
+  import _ from "lodash"
   import { computed } from "vue";
   import BalanceLogo from "../../images/icons/balance.svg"
   import Svg from "@components/Svg.vue"
-  import { getStudy, getProductStudies, getCountryStudies } from "@utils/data";
+  import { getStudy, getProduct, getCountry, getProductStudies, getCountryStudies } from "@utils/data";
   import { getStudyListQueryString } from "@utils/router";
 
   const props = defineProps({
@@ -34,6 +37,18 @@
         return getCountryStudies(getStudy(props.studyId).country);
       default:
         return [];
+    }
+  })
+  const title = computed(() => {
+    switch(props.type) {
+      case "product":
+        const product = getProduct(getStudy(props.studyId).product).prettyName;
+        return `Compare the ${otherStudies.value.length} ${_.capitalize(product)} studies`;
+      case "country":
+        const country = getCountry(getStudy(props.studyId).country).prettyName;
+        return `Compare the ${otherStudies.value.length} ${_.capitalize(country)} studies`;
+      default:
+        return "";
     }
   })
 </script>

--- a/src/components/study/ComparisonLink.vue
+++ b/src/components/study/ComparisonLink.vue
@@ -1,0 +1,54 @@
+<template>
+  <RouterLink
+    class="comparison-link"
+    :to="{
+      name: 'comparison',
+      query: { studies: getStudyListQueryString(otherStudies) }
+    }"
+  >
+    <Svg :svg="BalanceLogo" height="18px"/>
+    {{ otherStudies.length }}
+  </RouterLink>
+</template>
+
+<script setup>
+  import { computed } from "vue";
+  import BalanceLogo from "../../images/icons/balance.svg"
+  import Svg from "@components/Svg.vue"
+  import { getStudy, getProductStudies, getCountryStudies } from "@utils/data";
+  import { getStudyListQueryString } from "@utils/router";
+
+  const props = defineProps({
+    type: {
+      type: String,
+      validator: (typeProp) => ["product", "country"].includes(typeProp) 
+    },
+    studyId: String
+  })
+
+  const otherStudies = computed(() => {
+    switch(props.type) {
+      case "product":
+        return getProductStudies(getStudy(props.studyId).product);
+      case "country":
+        return getCountryStudies(getStudy(props.studyId).country);
+      default:
+        return [];
+    }
+  })
+</script>
+
+<style scoped lang="scss">
+  .comparison-link {
+    display: flex;
+    height: 20px;
+    color: #656565;
+    gap: 0.25rem;
+    font-size: 18px;
+    line-height: 18px;
+
+    &:hover {
+      color: #1C64F2;
+    }
+  }
+</style>

--- a/src/components/study/ComparisonLink.vue
+++ b/src/components/study/ComparisonLink.vue
@@ -1,16 +1,21 @@
 <template>
   <RouterLink
-    class="comparison-link"
-    :to="{
-      name: 'comparison',
-      query: { studies: getStudyListQueryString(otherStudies) }
-    }"
+    v-if="! disabled"
+    class="comparison-link "
+    :to="route"
     :title="title"
     target="_blank"
   >
-    <Svg :svg="BalanceLogo" height="18px"/>
+    <Svg :svg="BalanceLogo" height="20px"/>
     {{ otherStudies.length }}
   </RouterLink>
+  <span
+    v-else
+    class="no-comparison"
+    :title="noStudyTitle"
+  >
+    <Svg :svg="BalanceLogo" height="20px"/>
+  </span>
 </template>
 
 <script setup>
@@ -39,6 +44,14 @@
         return [];
     }
   })
+
+  const route = computed(() => {
+    if (disabled.value) { return {}; }
+    return {
+      name: "comparison",
+      query: { studies: getStudyListQueryString(otherStudies.value) }
+    }
+  })
   const title = computed(() => {
     switch(props.type) {
       case "product":
@@ -51,19 +64,35 @@
         return "";
     }
   })
+  const noStudyTitle = computed(() => {
+    return `No other study for this ${props.type}`;
+  })
+
+  const disabled = computed(() => {
+    return otherStudies.value.length <= 1;
+  });
 </script>
 
 <style scoped lang="scss">
-  .comparison-link {
+  .comparison-link, .no-comparison {
     display: flex;
     height: 20px;
-    color: #656565;
     gap: 0.25rem;
     font-size: 18px;
     line-height: 18px;
+    height: 20px;
+    align-items: flex-end;
+  }
+
+  .comparison-link {
+    color: #656565;
+    cursor: pointer;
 
     &:hover {
       color: #1C64F2;
     }
+  }
+  .no-comparison {
+    color: #BBB;
   }
 </style>

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -1,11 +1,25 @@
 <template>
     <div class="header">
         <div>
-            <div class="title">{{ commodityName }}</div>
+            <div class="title">
+              {{ commodityName }}
+              <ComparisonLink
+                class="link"
+                type="product"
+                :studyId="studyData.id"
+              />
+            </div>
             <div class="subtitle">Commodity</div>
         </div>
         <div>
-            <div class="title">{{ dataToDisplay.country }}</div>
+            <div class="title">
+              {{ dataToDisplay.country }}
+              <ComparisonLink
+                class="link"
+                type="country"
+                :studyId="studyData.id"
+              />
+            </div>
             <div class="subtitle">Country</div>
         </div>
         <div>
@@ -23,6 +37,7 @@
 import { computed } from 'vue'
 import { getCurrencySymbol } from '@utils/currency.js'
 import { getCountry, getProduct, getStudy } from '@utils/data'
+import ComparisonLink from '@components/study/ComparisonLink.vue';
 
 const props = defineProps({
     studyData: {
@@ -72,6 +87,13 @@ let dataToDisplay = computed(() => {
     .title {
         @apply text-[#303030] text-3xl font-thin;
         text-transform: capitalize;
+        display: flex;
+        align-items: flex-end;
+        gap: 0.5rem;
+
+        .link {
+          margin-bottom: 5px;
+        }
     }
   }
 </style>

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -1,30 +1,20 @@
 <template>
-    <div class="text-xl rounded bg-[#dcefbb] flex flex-row flex-wrap gap-y-4 py-3 pl-8 rounded-none md:rounded-full justify-center md:justify-start">
-        <div class="bloc">
+    <div class="header">
+        <div>
             <div class="title">{{ commodityName }}</div>
             <div class="subtitle">Commodity</div>
         </div>
-        <div class="bloc">
+        <div>
             <div class="title">{{ dataToDisplay.country }}</div>
             <div class="subtitle">Country</div>
         </div>
-        <div class="bloc">
+        <div>
             <div class="title">{{ studyData.targetCurrency ? getCurrencySymbol(studyData.targetCurrency) : '-'}}</div>
             <div class="subtitle">Local currency</div>
         </div>
-        <div class="bloc">
+        <div>
             <div class="title">{{ studyData.year }}</div>
             <div class="subtitle">Reference year</div>
-        </div>
-        <div v-if="false">
-            <RouterLink :to="`/comparison/${commodityId}`">
-                Compare all {{ commodityName }} studies
-            </RouterLink>
-        </div>
-        <div v-if="false">
-            <RouterLink :to="`/comparison/${studyData.country}`">
-                Compare all {{ dataToDisplay.country }} studies
-            </RouterLink>
         </div>
     </div>
 </template>
@@ -67,6 +57,15 @@ let dataToDisplay = computed(() => {
 </script>
 
 <style scoped lang="scss">
+  .header {
+    display: flex;
+    gap: 5rem;
+    border-radius: 10000px;
+    justify-content: flex-start;
+    padding: 0.75rem 2rem;
+    background-color: #dcefbb;
+    flex-wrap: wrap;
+
     .subtitle {
         @apply text-[#656565] text-xs;
     }
@@ -74,7 +73,5 @@ let dataToDisplay = computed(() => {
         @apply text-[#303030] text-3xl font-thin;
         text-transform: capitalize;
     }
-    .bloc {
-        @apply mr-20
-    }
+  }
 </style>

--- a/src/images/icons/balance.svg
+++ b/src/images/icons/balance.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 50 50" style="enable-background:new 0 0 50 50;" xml:space="preserve">
+<g fill="none" stroke="currentColor" stroke-width="2.5" stroke-miterlimit="10">
+	<line x1="25" y1="6.4" x2="25" y2="43.6"/>
+	<line x1="12.3" y1="43.6" x2="37.7" y2="43.6"/>
+	<line x1="9.3" y1="10.7" x2="40.7" y2="10.7"/>
+	<path d="M48.7,23.1c0,4.7-3.8,8.6-8.6,8.6s-8.6-3.8-8.6-8.6H48.7z"/>
+	<polyline points="34.8,22.4 39.7,10.7 40.7,10.7 45.7,22.4 	"/>
+	<path d="M1.3,23.1c0,4.7,3.8,8.6,8.6,8.6c4.7,0,8.6-3.8,8.6-8.6H1.3z"/>
+	<polyline points="15.3,22.4 10.4,10.7 9.3,10.7 4.4,22.4 	"/>
+</g>
+</svg>

--- a/src/utils/data/json.js
+++ b/src/utils/data/json.js
@@ -46,3 +46,15 @@ export function getStudy(studyId) {
   const jsonStudies = jsonData.studies;
   return jsonStudies.find(study => study.id === studyId);
 }
+
+export function getProductStudies(productId) {
+  return jsonData.studies
+    .filter(study => study.product === productId)
+    .map(study => study.id);
+}
+
+export function getCountryStudies(countryId) {
+  return jsonData.studies
+    .filter(study => study.country === countryId)
+    .map(study => study.id);
+}


### PR DESCRIPTION
Resolves #46 

# Contexte

On veut simplifier la comparaison d'une étude avec celles qui ont le meme produit/pays
On ajoute donc des liens vers les bonnes pages de comparaison dans le header

:construction: J'ai pris l'initiative sur le design, et cela passera par une review de Gaspard dès demain

| avant | après |
| - | - |
| ![image](https://github.com/user-attachments/assets/83f32003-85d5-469e-99b5-3e8a3a6d540f) | ![image](https://github.com/user-attachments/assets/fcf6dd4a-f271-4f73-b76e-b0624ffdc351) | 

## Changements

- Ajout d'un composant `ComparisonLink` qui encapsule la récuperation des bonnes infos et le logo
- Integration de ce composant dans `StudyHeader`