### PR TITLE
feat: Format a real section for the filters

### DIFF
--- a/src/components/home/ByCategories.vue
+++ b/src/components/home/ByCategories.vue
@@ -1,4 +1,5 @@
 <script setup>
+import QuestionTitle from '@components/study/QuestionTitle.vue';
 import ByCategory from './ByCategory.vue'
 
 const props = defineProps({
@@ -32,8 +33,8 @@ const filterStudiesByCategory = (category) => {
 
 <template>
     <section>
-        <h2>Browse studies by <strong>product</strong></h2>
-        <template v-for="category in categories" :key="category.id">
+        <QuestionTitle>By <strong>product</strong></QuestionTitle>
+        <template v-for="(category) in categories" :key="category.id">
             <ByCategory :studies="filterStudiesByCategory(category.id)" :countries="countries" :category="category" :currency="currency"/>
         </template>
     </section>

--- a/src/components/home/ByContinents.vue
+++ b/src/components/home/ByContinents.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import ByContinent from './ByContinent.vue';
+import QuestionTitle from '@components/study/QuestionTitle.vue';
 
 
 const props = defineProps({
@@ -20,12 +21,15 @@ const getStudiesByContinent = (continent) => {
 
 <template>
     <section>
-        <h2>Browse studies by <strong>country</strong></h2>
+        <QuestionTitle>By <strong>country</strong></QuestionTitle>
         <template v-for="continent in continents" :key="continent">
-            <ByContinent :continent="continent" :studies="getStudiesByContinent(continent)" :countries="countries" :currency="currency"/>
+            <ByContinent class="continent" :continent="continent" :studies="getStudiesByContinent(continent)" :countries="countries" :currency="currency"/>
         </template>
     </section>
 </template>
 
 <style scoped lang="scss">
+.continent:not(:first-child) {
+  margin-top: 48px;
+}
 </style>

--- a/src/components/home/Section.vue
+++ b/src/components/home/Section.vue
@@ -7,8 +7,8 @@ const props = defineProps({
 </script>
 
 <template>
-    <section>
-        <h4 :style="`margin-top: 48px; color: ${textColor};`">{{ title }}</h4>
+    <section class="section">
+        <h4 :style="`color: ${textColor};`">{{ title }}</h4>
         <div class="border-t-[13px] pt-4" :style="`border-color: ${borderColor};`">
         <slot></slot>
         </div>  
@@ -16,5 +16,7 @@ const props = defineProps({
 </template>
 
 <style scoped lang="scss">
-
+  .section {
+    margin-top: 48px;
+  }
 </style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -98,13 +98,21 @@ function toggleFilter(filterKey) {
         </ul>
       </section>
       <section>
-        <div class="flex gap-2">
-          <FilterInput label="With economic data" :value="mandatoryStudiesFilter.ecoData" @toggle="toggleFilter('ecoData')"/>
-          <FilterInput label="With environnemental data" :value="mandatoryStudiesFilter.acvData" @toggle="toggleFilter('acvData')"/>
-          <FilterInput label="With social profil" :value="mandatoryStudiesFilter.socialData" @toggle="toggleFilter('socialData')"/>
+        <h2><strong>Browse studies</strong></h2>
+        <div class="filter-section">
+          <p>Filter the studies on this page based on the topics addressed.</p>
+          <div>
+            <FilterInput label="With economic data" :value="mandatoryStudiesFilter.ecoData" @toggle="toggleFilter('ecoData')"/>
+            <FilterInput label="With environnemental data" :value="mandatoryStudiesFilter.acvData" @toggle="toggleFilter('acvData')"/>
+            <FilterInput label="With social profil" :value="mandatoryStudiesFilter.socialData" @toggle="toggleFilter('socialData')"/>
+          </div>
+          <p>
+            <div>
+              Number of studies: {{ filteredStudies.length }}
+            </div>
+          </p>
         </div>
         
-        <div>Number of studies: {{ filteredStudies.length }}</div>
       </section>
       <ByCategories
         :categories="categories"
@@ -182,5 +190,11 @@ section.banner {
   h1 {
     margin-bottom: 1rem;
   }
+}
+
+.filter-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 </style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -81,7 +81,7 @@ function toggleFilter(filterKey) {
         </p>
         <p>
           The European Commission has developed the VCA4D standardised methodological framework for
-          analysis (<a target="_blank" class="text-blue-600" href="https://capacity4dev.europa.eu/info/1-vca4d-methodology_en">The VCA4D Methodology | Capacity4dev</a>). It aims at understanding to what extent
+          analysis (<a target="_blank" class="link" href="https://capacity4dev.europa.eu/info/1-vca4d-methodology_en">The VCA4D Methodology | Capacity4dev</a>). It aims at understanding to what extent
           the value chain allows for inclusive economic growth and whether it is both socially and
           environmentally sustainable.
         </p>
@@ -109,6 +109,9 @@ function toggleFilter(filterKey) {
           <p>
             <div>
               Number of studies: {{ filteredStudies.length }}
+            </div>
+            <div>
+              You can also <RouterLink class="link" :to="{ name: 'comparison' }">compare studies</RouterLink> based on key indicators
             </div>
           </p>
         </div>
@@ -196,5 +199,13 @@ section.banner {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.link {
+  color: #1C64F2;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 </style>


### PR DESCRIPTION
## Contexte

On redesigne un peu la sectiond des filtres dans la home pour 

- Avoir un vrai highlight sur cette section
- Ajouter un lien vers la page de comparaison

| Avant | Après |
| - | - |
| ![image](https://github.com/user-attachments/assets/5e129b77-cda2-4a08-a3f7-9acaeb6796ba) |![image](https://github.com/user-attachments/assets/ecfe891f-460a-4b54-a441-78b07ca3432f) |
