### PR TITLE
fix: Don't capitalize pretty names

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -564,27 +564,27 @@
   "products": [
     {
       "id": "cocoa",
-      "prettyName": "cocoa"
+      "prettyName": "Cocoa"
     },
     {
       "id": "coffee",
-      "prettyName": "coffee"
+      "prettyName": "Coffee"
     },
     {
       "id": "cashew",
-      "prettyName": "cashew"
+      "prettyName": "Cashew"
     },
     {
       "id": "banana",
-      "prettyName": "banana"
+      "prettyName": "Banana"
     },
     {
       "id": "mango",
-      "prettyName": "mango"
+      "prettyName": "Mango"
     },
     {
       "id": "vanilla",
-      "prettyName": "vanilla"
+      "prettyName": "Vanilla"
     },
     {
       "id": "oil palm",
@@ -592,67 +592,67 @@
     },
     {
       "id": "beef",
-      "prettyName": "beef"
+      "prettyName": "Beef"
     },
     {
       "id": "egg",
-      "prettyName": "egg"
+      "prettyName": "Egg"
     },
     {
       "id": "milk",
-      "prettyName": "milk"
+      "prettyName": "Milk"
     },
     {
       "id": "cassava",
-      "prettyName": "cassava"
+      "prettyName": "Cassava"
     },
     {
       "id": "cotton",
-      "prettyName": "cotton"
+      "prettyName": "Cotton"
     },
     {
       "id": "groundnut",
-      "prettyName": "groundnut"
+      "prettyName": "Groundnut"
     },
     {
       "id": "cowpea",
-      "prettyName": "cowpea"
+      "prettyName": "Cowpea"
     },
     {
       "id": "french beans",
-      "prettyName": "green beans"
+      "prettyName": "Green beans"
     },
     {
       "id": "maize",
-      "prettyName": "maize"
+      "prettyName": "Maize"
     },
     {
       "id": "sorghum",
-      "prettyName": "sorghum"
+      "prettyName": "Sorghum"
     },
     {
       "id": "pineapple",
-      "prettyName": "pineapple"
+      "prettyName": "Pineapple"
     },
     {
       "id": "freshwater-aquaculture",
-      "prettyName": "freshwater-aquaculture"
+      "prettyName": "Freshwater-aquaculture"
     },
     {
       "id": "aquaculture",
-      "prettyName": "aquaculture"
+      "prettyName": "Aquaculture"
     },
     {
       "id": "coastal fisheries",
-      "prettyName": "coastal fisheries"
+      "prettyName": "Coastal fisheries"
     },
     {
       "id": "inland fisheries",
-      "prettyName": "inland fisheries"
+      "prettyName": "Inland fisheries"
     },
     {
       "id": "fisheries",
-      "prettyName": "fisheries"
+      "prettyName": "Fisheries"
     }
   ]
 }

--- a/data/data.json
+++ b/data/data.json
@@ -588,7 +588,7 @@
     },
     {
       "id": "oil palm",
-      "prettyName": "Palm Oil"
+      "prettyName": "Palm oil"
     },
     {
       "id": "beef",
@@ -636,7 +636,7 @@
     },
     {
       "id": "freshwater-aquaculture",
-      "prettyName": "Freshwater-aquaculture"
+      "prettyName": "Freshwater aquaculture"
     },
     {
       "id": "aquaculture",

--- a/src/components/comparison/StudiesListTable.vue
+++ b/src/components/comparison/StudiesListTable.vue
@@ -15,7 +15,6 @@
 </template>
 
 <script setup>
-  import _ from "lodash";
   import DataTable from "@components/charts/DataTable.vue";
   import { onMounted, ref } from 'vue';
   import { getAllJsonData, getStudy, getStudyData, getProduct, getCountry } from '@utils/data';
@@ -39,8 +38,8 @@
     const studyData = await getStudyData(id);
     return {
       id: studyData.id,
-      product: _.capitalize(getProduct(getStudy(studyData.id).product).prettyName),
-      country: _.capitalize(getCountry(getStudy(studyData.id).country).prettyName),
+      product: getProduct(getStudy(studyData.id).product).prettyName,
+      country: getCountry(getStudy(studyData.id).country).prettyName,
       isEcoAvailable: isAvailable(studyData, "ecoData"),
       isSocialAvailable: isAvailable(studyData, "socialData"),
       isAcvAvailable: isAvailable(studyData, "acvData")

--- a/src/components/home/ByContinent.vue
+++ b/src/components/home/ByContinent.vue
@@ -69,7 +69,7 @@ const getStudiesByCountry = () => {
                             <LogoCountryLarge :isoCode="getCountry(item.country).iso || 'gr'" />
                         </template>
                         <template v-slot:footer>
-                            <CardFooter class="capitalize" :text="getProduct(item.studies[0].product).prettyName">
+                            <CardFooter class="" :text="getProduct(item.studies[0].product).prettyName">
                                 <template v-slot:logo>
                                     <LogoProductSmall :product-name="item.studies[0].product"/>
                                 </template>

--- a/src/components/home/Card.vue
+++ b/src/components/home/Card.vue
@@ -17,7 +17,7 @@ const props = defineProps({
         <component :is="link ? 'RouterLink' : 'v-fragment'" :to="link" class="w-[150px]">
             <div :class="`cursor-pointer card-icon ${isLocal ? 'bg-[#868686]' : (isOpen ? 'bg-[#9B9B9B]' :  'bg-[#DFDFDF]')} hover:bg-[#CFCFCF]`">
                 <slot name="logo"></slot>
-                <p class="font-semibold capitalize text-center">{{ title }}</p>
+                <p class="font-semibold text-center">{{ title }}</p>
             </div>  
         </component>
         <slot name="footer"></slot>   

--- a/src/components/import/SaveOnGithubStep.vue
+++ b/src/components/import/SaveOnGithubStep.vue
@@ -24,6 +24,7 @@
 </template>
 
 <script setup>
+import _ from "lodash";
 import { computed } from 'vue';
 
 import jsonData from '@data/data.json'
@@ -107,7 +108,7 @@ function updateProductList(products = [], existingProductKeys) {
     if (!products.find(product => product.id === productKey)) {
       newProducts.push({
         id: productKey,
-        prettyName: productKey 
+        prettyName: _.capitalize(productKey) 
       });
     }
   });

--- a/src/components/study/ComparisonLink.vue
+++ b/src/components/study/ComparisonLink.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script setup>
+  import _ from "lodash";
   import { computed } from "vue";
   import BalanceLogo from "../../images/icons/balance.svg"
   import Svg from "@components/Svg.vue"
@@ -49,7 +50,7 @@
 
     switch(props.type) {
       case "product":
-        const product = getProduct(getStudy(props.studyId).product).prettyName;
+        const product = _.lowerCase(getProduct(getStudy(props.studyId).product).prettyName);
         return `Compare the ${allStudies.value.length} ${product} studies`;
       case "country":
         const country = getCountry(getStudy(props.studyId).country).prettyName;

--- a/src/components/study/ComparisonLink.vue
+++ b/src/components/study/ComparisonLink.vue
@@ -10,7 +10,6 @@
 </template>
 
 <script setup>
-  import _ from "lodash"
   import { computed } from "vue";
   import BalanceLogo from "../../images/icons/balance.svg"
   import Svg from "@components/Svg.vue"
@@ -51,10 +50,10 @@
     switch(props.type) {
       case "product":
         const product = getProduct(getStudy(props.studyId).product).prettyName;
-        return `Compare the ${allStudies.value.length} ${_.capitalize(product)} studies`;
+        return `Compare the ${allStudies.value.length} ${product} studies`;
       case "country":
         const country = getCountry(getStudy(props.studyId).country).prettyName;
-        return `Compare the ${allStudies.value.length} ${_.capitalize(country)} studies`;
+        return `Compare the ${allStudies.value.length} ${country} studies`;
       default:
         return "";
     }

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -87,7 +87,6 @@ let dataToDisplay = computed(() => {
     }
     .title {
         @apply text-[#303030] text-3xl font-thin;
-        text-transform: capitalize;
         display: flex;
         align-items: flex-end;
         gap: 0.5rem;


### PR DESCRIPTION
Resolves #65 

## Contexte

A plusieurs endroits du code, on "capitalize" les noms de produits/pays. Hors

- `_.capitalize` et la class tailwind `capitalize` n'ont pas le meme effet (le premier ne met en upppercase que la premiere lettre de la string, le 2e de tous les mots)
- On risque alors de déformer le nom des pays, bien rentré dans les json d'étude

## Changements

- On arrete de `capitalize` à tout va
- On fige le pretty name des product avec une Majuscule au début
- On `lowerCase` la seule fois ou un produit est dans une phrase (les pays sont toujours avec des majuscules)