### PR TITLE
feat: Use normal graph colors for environment graphs

### DIFF
--- a/src/charts/charts.js
+++ b/src/charts/charts.js
@@ -1,5 +1,5 @@
 import { formatNumber, formatPercent } from '@utils/format.js'
-import { getColor, getRingColor, COLORS_IMPORTED_PRODUCTS, COLORS_EXPORTED_PRODUCTS } from '@utils/colors.js'
+import { getColor, COLORS_IMPORTED_PRODUCTS, COLORS_EXPORTED_PRODUCTS } from '@utils/colors.js'
 import { getStageLabel } from '../utils/stages'
 const RADIUSES_MINI_PIE = ['20%', '40%']
 const RIADUSES_PIE = ['50%', '75%']
@@ -9,7 +9,7 @@ const SELECTED_COLOR_HOVER = "#f7d9de"
 /*
 * RING CHART
 */
-export const getRingChart = (items, tooltip, title, isEnvironment = false) => {
+export const getRingChart = (items, tooltip, title) => {
     return {
         title: {
             text: title,
@@ -37,7 +37,7 @@ export const getRingChart = (items, tooltip, title, isEnvironment = false) => {
                 radius: RIADUSES_PIE,
                 itemStyle: {
                     color: function (info) {
-                        return isEnvironment ? getRingColor(info.name) : getColor(info.name)
+                        return getColor(info.name)
                     }
                 }
             }

--- a/src/components/study/environment/ImpactDataviz.vue
+++ b/src/components/study/environment/ImpactDataviz.vue
@@ -30,7 +30,7 @@ import BarChart from '@charts/BarChart.vue'
 import Ring from '@charts/Ring.vue'
 import InfoTitle from '@typography/InfoTitle.vue'
 import { formatNumber } from '@utils/format.js'
-import { getRingColor } from '@utils/colors.js'
+import { getColor } from '@utils/colors.js'
 import { ACVImpacts } from '@utils/misc.js'
 
 const props = defineProps({
@@ -75,7 +75,7 @@ const populatedRingChartData = computed(() => {
       },
     }
   })
-  var series = getRingChart(items, tooltip, "", true)
+  var series = getRingChart(items, tooltip, "")
   return series
 })
 
@@ -86,7 +86,7 @@ const detailBarChartOptions = computed(() => {
   props.impact.values.filter(item => item.valuechain_name == selectedValueChain.value)
   .forEach(item => {
     labels.push(item.actor_name)
-    var color = getRingColor(item.actor_name)
+    var color = getColor(item.actor_name)
     values.push({
         value: item.value,
         itemStyle: {

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -42,23 +42,6 @@ export const getColor = (itemName) => {
   return DynamicColorsMapping[itemName]
 }
 
-const RING_COLORS = [
-  '#8B0000',
-  '#00008B',
-  '#006400',
-  '#4B0082',
-  '#5A3A3A',
-  '#008080'
-]
-
-let ringColors = {}
-export const getRingColor = (name) => {
-  if (!(name in ringColors)) {
-    ringColors[name] = RING_COLORS[Object.keys(ringColors).length % RING_COLORS.length]
-  }
-  return ringColors[name]
-} 
-
 export const getSocialScoreColor = (value) => {
   if (value < 1.5) {
     return AVAILABLE_COLORS["BadScoreRed"]


### PR DESCRIPTION
Relié à #61 

## Contexte

Les graphes coté environnement ne sont pas beaux

## Solution

On utilise les memes couleurs par défaut que dans les pages economiques

| Avant | Après |
|-|-|
| ![image](https://github.com/user-attachments/assets/72b447c7-9735-4f73-83e6-2b69611ee2ce) | ![image](https://github.com/user-attachments/assets/c48ea07d-582f-4ad2-b916-56774a0eb4b3) |