### PR TITLE
feat(62): Refactor unit settings in study's ACV page

### DIFF
--- a/src/components/StudyEnvironment.vue
+++ b/src/components/StudyEnvironment.vue
@@ -90,14 +90,13 @@ const yearlyVolumes = computed(() => {
 })
 
 const units = [
-  { label: 'Pt', value: 'PT' },
-  { label: 'Other units', value: 'OTHER' },
+  { label: 'Single score (Pt)', value: 'PT', subtitle: 'Different impacts (climate, health, water etc.) are expressed in a single weighted unit.' },
+  { label: 'Different units', value: 'OTHER', subtitle: 'Each impact is expressed in its own unit' },
 ];
 
 const perUnits = [
-  {
-    label: "Per year", value: "year"},
-    {label: "Per functional unit", value: "functional unit"}
+  { label: "Total impact per year", value: "year", subtitle: "See which sub-chain currently has most impact in the country" },
+  { label: "Impact per functional unit", value: "functional unit", subtitle: "Compare best performing production systems" }
 ]
 
 const selectedUnit = ref(units[0].value);

--- a/src/components/StudyEnvironment.vue
+++ b/src/components/StudyEnvironment.vue
@@ -33,45 +33,17 @@
       Sub-chains can be compared according to the damage they generate in the three areas of protection. 
       This highlights the gaps between them and helps determine actions for environmental improvements.
     </p>
-    <div class="flex flex-row justify-center gap-x-20 mb-8 mt-4">
-      <div class="flex flex-row justify-center gap-x-4">
-          <label v-for="unit in units" :key="unit.value"
-          :class="{
-            'inline-block w-40 h-10 text-center py-2 border-2 rounded cursor-pointer text-black text-md': true,
-            'border-blue-200 bg-blue-100': selectedUnit === unit.value,
-            'border-gray-200 bg-gray-100': selectedUnit !== unit.value 
-          }" 
-            >
-            <input
-            type="radio"
-            :id="unit.value"
-            :value="unit.value"
-            v-model="selectedUnit"
-            name="radioGroup"
-            class="hidden"
-            />
-            {{ unit.label }}
-          </label>
-      </div>
-      <div class="flex flex-row justify-center gap-x-4">
-          <label v-for="perUnit in perUnits" :key="perUnit.value"
-          :class="{
-            'inline-block w-40 h-10 text-center py-2 border-2 rounded cursor-pointer text-black text-md': true,
-            'border-blue-200 bg-blue-100': selectedPerUnit === perUnit.value,
-            'border-gray-200 bg-gray-100': selectedPerUnit !== perUnit.value 
-          }" 
-            >
-            <input
-            type="radio"
-            :id="perUnit.value"
-            :value="perUnit.value"
-            v-model="selectedPerUnit"
-            name="radioGroup"
-            class="hidden"
-            />
-            {{ perUnit.label }}
-          </label>
-      </div>
+    <div class="flex">
+      <RadioInput
+        :options="perUnits"
+        :selected="selectedPerUnit"
+        @update:selected="$event => selectedPerUnit = $event"
+      />
+      <RadioInput
+        :options="units"
+        :selected="selectedUnit"
+        @update:selected="$event => selectedUnit = $event"
+      />
     </div>
     <template v-if="studyData">
       <div v-for="impact in allBarChartsData" :key="impact.name">
@@ -89,6 +61,7 @@ import ImpactDataviz from '@components/study/environment/ImpactDataviz.vue'
 import { ACVImpacts } from '@utils/misc.js'
 import QuestionTitle from "@components/study/QuestionTitle.vue"
 import AttachmentLink from '@components/pdf/AttachmentLink.vue'
+import RadioInput from '@components/study/RadioInput.vue'
 
 const props = defineProps({
   studyData: Object

--- a/src/components/StudyEnvironment.vue
+++ b/src/components/StudyEnvironment.vue
@@ -33,19 +33,22 @@
       Sub-chains can be compared according to the damage they generate in the three areas of protection. 
       This highlights the gaps between them and helps determine actions for environmental improvements.
     </p>
-    <div class="flex">
-      <RadioInput
-        title="Scope of the results"
-        :options="perUnits"
-        :selected="selectedPerUnit"
-        @update:selected="$event => selectedPerUnit = $event"
-      />
-      <RadioInput
-        title="Unit of the impact"
-        :options="units"
-        :selected="selectedUnit"
-        @update:selected="$event => selectedUnit = $event"
-      />
+    <div class="unit-selection">
+      <div class="unit-selection-title">Unit Selection</div>
+      <div class="unit-inputs">
+        <RadioInput
+          title="Scope of the results"
+          :options="perUnits"
+          :selected="selectedPerUnit"
+          @update:selected="$event => selectedPerUnit = $event"
+        />
+        <RadioInput
+          title="Unit of the impact"
+          :options="units"
+          :selected="selectedUnit"
+          @update:selected="$event => selectedUnit = $event"
+        />
+      </div>
     </div>
     <template v-if="studyData">
       <div v-for="impact in allBarChartsData" :key="impact.name">
@@ -104,4 +107,25 @@ const selectedPerUnit = ref(perUnits[0].value);
 
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.unit-selection {
+  margin: 32px 0;
+  
+  .unit-selection-title {
+    text-transform: uppercase;
+    font-weight: 700;
+    color: #8A8A8A;
+    margin-bottom: 16px;
+  }
+
+  .unit-inputs {
+    display: flex;
+    gap: 30px;
+    margin: 16px 0;
+    > * {
+      flex-grow: 1;
+      max-width: 50%;
+    }
+  }
+}
+</style>

--- a/src/components/StudyEnvironment.vue
+++ b/src/components/StudyEnvironment.vue
@@ -35,11 +35,13 @@
     </p>
     <div class="flex">
       <RadioInput
+        title="Scope of the results"
         :options="perUnits"
         :selected="selectedPerUnit"
         @update:selected="$event => selectedPerUnit = $event"
       />
       <RadioInput
+        title="Unit of the impact"
         :options="units"
         :selected="selectedUnit"
         @update:selected="$event => selectedUnit = $event"

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -167,7 +167,6 @@
     cursor: pointer;
 
     input {
-      accent-color: #3F83F8;
       cursor: pointer;
     }
   }

--- a/src/components/study/RadioInput.vue
+++ b/src/components/study/RadioInput.vue
@@ -1,0 +1,33 @@
+<template>
+  <label v-for="option in options" :key="option.value">
+    <input
+      type="radio"
+      :id="uniqueId"
+      :value="option.value"
+      :checked="selected === option.value"
+      @input="emits('update:selected', option.value)"
+    />
+    {{ option.label }}
+  </label>
+</template>
+
+<script setup lang="ts">
+  import { computed, getCurrentInstance } from 'vue';
+
+  type Option = { label: string; value: string };
+  defineProps<{
+      options: Option[],
+      selected: string
+  }>();
+
+  const emits = defineEmits<{
+    "update:selected": [value: string]
+  }>()
+
+  const uniqueId = computed(() => {
+    return getCurrentInstance()?.uid; // This is a unique component instance id
+  });
+</script>
+
+<style scoped lang="scss">
+</style>

--- a/src/components/study/RadioInput.vue
+++ b/src/components/study/RadioInput.vue
@@ -1,14 +1,17 @@
 <template>
-  <label v-for="option in options" :key="option.value">
-    <input
-      type="radio"
-      :id="uniqueId"
-      :value="option.value"
-      :checked="selected === option.value"
-      @input="emits('update:selected', option.value)"
-    />
-    {{ option.label }}
-  </label>
+  <div class="radio-input">
+    <span class="title">{{ title }}</span>
+    <label v-for="option in options" :key="option.value">
+      <input
+        type="radio"
+        :id="uniqueId"
+        :value="option.value"
+        :checked="selected === option.value"
+        @input="emits('update:selected', option.value)"
+      />
+      {{ option.label }}
+    </label>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -17,7 +20,8 @@
   type Option = { label: string; value: string };
   defineProps<{
       options: Option[],
-      selected: string
+      selected: string,
+      title: string
   }>();
 
   const emits = defineEmits<{
@@ -30,4 +34,13 @@
 </script>
 
 <style scoped lang="scss">
+.radio-input {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+
+  .title {
+    font-weight: 700;
+  }
+}
 </style>

--- a/src/components/study/RadioInput.vue
+++ b/src/components/study/RadioInput.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="radio-input">
     <span class="title">{{ title }}</span>
-    <div class="option" v-for="option in options" :key="option.value">
-      <label>
-        <input
-          type="radio"
-          :id="uniqueId"
-          :value="option.value"
-          :checked="selected === option.value"
-          @input="emits('update:selected', option.value)"
-        />
-        <span class="label">{{ option.label }}</span>
-      </label>
-      <span class="subtitle">{{ option.subtitle }}</span>
-    </div>
+    <label class="option" v-for="option in options" :key="option.value">
+      <input
+        type="radio"
+        :id="uniqueId"
+        :value="option.value"
+        :checked="selected === option.value"
+        @input="emits('update:selected', option.value)"
+      />
+      <span class="label">
+        <span>{{ option.label }}</span>
+        <span class="subtitle">{{ option.subtitle }}</span>
+      </span>
+    </label>
   </div>
 </template>
 
@@ -48,16 +48,22 @@
 
   .option {
     display: flex;
-    flex-direction: column;
+    align-items: flex-start;
+    cursor: pointer;
+
+    input {
+      margin-top: 6px
+    }
 
     .label {
       margin-left: 6px;
-    }
+      display: flex;
+      flex-direction: column;
 
-    .subtitle {
-      margin-left: 20px;
-      color: #8a8a8a;
-      font-style: italic;
+      .subtitle {
+        color: #8a8a8a;
+        font-style: italic;
+      }
     }
   }
 }

--- a/src/components/study/RadioInput.vue
+++ b/src/components/study/RadioInput.vue
@@ -1,23 +1,26 @@
 <template>
   <div class="radio-input">
     <span class="title">{{ title }}</span>
-    <label v-for="option in options" :key="option.value">
-      <input
-        type="radio"
-        :id="uniqueId"
-        :value="option.value"
-        :checked="selected === option.value"
-        @input="emits('update:selected', option.value)"
-      />
-      {{ option.label }}
-    </label>
+    <div class="option" v-for="option in options" :key="option.value">
+      <label>
+        <input
+          type="radio"
+          :id="uniqueId"
+          :value="option.value"
+          :checked="selected === option.value"
+          @input="emits('update:selected', option.value)"
+        />
+        <span class="label">{{ option.label }}</span>
+      </label>
+      <span class="subtitle">{{ option.subtitle }}</span>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
   import { computed, getCurrentInstance } from 'vue';
 
-  type Option = { label: string; value: string };
+  type Option = { label: string; value: string, subtitle: string };
   defineProps<{
       options: Option[],
       selected: string,
@@ -41,6 +44,21 @@
 
   .title {
     font-weight: 700;
+  }
+
+  .option {
+    display: flex;
+    flex-direction: column;
+
+    .label {
+      margin-left: 6px;
+    }
+
+    .subtitle {
+      margin-left: 20px;
+      color: #8a8a8a;
+      font-style: italic;
+    }
   }
 }
 </style>

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -17,6 +17,7 @@ body {
     font-family: 'Source Sans Pro',-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     font-size: 16px;
     color: black;
+    accent-color: #3F83F8;
     /* text-rendering: optimizeLegibility; */
     /* -webkit-font-smoothing: antialiased; */
     /* -moz-osx-font-smoothing: grayscale; */


### PR DESCRIPTION
Resolves: #62

## Contexte

Dans la page d'étude ACV, le selecteur d'unité / de scope n'est pas très clair.
Sur proposition de gaspard, on l'améliore, en ajoutant des explications

| Avant | Après | 
|-|-|
| ![image](https://github.com/user-attachments/assets/5fa144f8-857a-48da-90b9-ab269ead2896) | ![image](https://github.com/user-attachments/assets/81297650-1af1-45fc-b628-d025a41012c2) |

## Changements

- Ajout d'un composant de selection d'option via RadioButton, pour l'utiliser à la place des boutons actuels
- Ajout de titres et sous-titres
- Styling