### PR TITLE
fix(73): Allow labels to expand

### DIFF
--- a/src/charts/charts.js
+++ b/src/charts/charts.js
@@ -29,6 +29,7 @@ export const getRingChart = (items, tooltip, title) => {
                     overflow: 'break',
                     bleedMargin: 0,
                     ellipsis: '..',
+                    width: 100,
                     formatter: params => params.data.label || params.data.name
                 },
                 type: 'pie',

--- a/src/components/study/economic-growth/AddedValue.vue
+++ b/src/components/study/economic-growth/AddedValue.vue
@@ -60,7 +60,7 @@
       <Ring
         v-if="studyData"
         :options="addedValueCreatorsRingChartData"
-        style="height: 400px; width: 500px"
+        style="height: 400px; width: 520px"
       ></Ring>
       <div class="font-semibold">{{ totalAddedValueCreators }}</div>
     </div>
@@ -68,7 +68,7 @@
       <Ring
         v-if="studyData"
         :options="addedValueReceiversRingChartData"
-        style="height: 400px; width: 500px"
+        style="height: 400px; width: 520px"
       ></Ring>
       <div class="font-semibold">{{ totalAddedValueReceivers }}</div>
     </div>


### PR DESCRIPTION
Resolves #73 

## Contexte

Dans un ring chart, certains labels ne mettent a la ligne que certaines lettres
De plus, certains labels ne sont pas montrés si la valeur est trop faible (cf "Financial institutions")


| Avant | Après |
| - | - |
| ![image](https://github.com/user-attachments/assets/a7241476-958d-478e-85ef-93155893ed54) | ![image](https://github.com/user-attachments/assets/74855815-c8ee-4178-9127-51f982783ef4) |

## Changements

- Définition d'une largeur des labels
- Plsu de largeur pour le graphique entier