### PR TITLE
feat(58): Include currency selector in study header

### DIFF
--- a/src/components/study/CurrencySelector.vue
+++ b/src/components/study/CurrencySelector.vue
@@ -1,0 +1,32 @@
+<template>
+  <select
+    class="border border-[#656565] text-[#868686] rounded-lg focus:ring-[#868686] focus:border-[#868686] block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+    v-model="selectedCurrency"
+    @change="emits('update:currency', $event.target.value)"
+  >
+    <option v-if="isCurrencySupported(localCurrency)" value="LOCAL">
+      {{ getCurrencyName(localCurrency) }} ({{ getCurrencySymbol(localCurrency) }})
+    </option>
+    <option v-else value="LOCAL">
+      {{ localCurrency }} ({{ getCurrencySymbol(localCurrency) }})
+    </option>
+    <option v-if="localCurrency !== 'USD' && isCurrencySupported(localCurrency)" value="USD">
+      {{ getCurrencyName('USD') }} ({{ getCurrencySymbol('USD') }})
+    </option>
+    <option v-if="localCurrency !== 'EUR' && isCurrencySupported(localCurrency)" value="EUR">
+      {{ getCurrencyName('EUR') }} ({{ getCurrencySymbol('EUR') }})
+    </option>
+  </select>
+</template>
+
+<script setup>
+import { getCurrencySymbol, getCurrencyName, isCurrencySupported } from '@utils/currency.js'
+import { ref } from 'vue';
+
+const props = defineProps({
+  localCurrency: String,
+  currency: String,
+})
+const selectedCurrency = ref(props.currency);
+const emits = defineEmits(['update:currency'])
+</script>

--- a/src/components/study/CurrencySelector.vue
+++ b/src/components/study/CurrencySelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="select-wrapper">
     <select
-      class="border border-[#656565] text-[#868686] rounded-lg focus:ring-[#868686] focus:border-[#868686] block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+      class="selector"
       v-model="selectedCurrency"
       @change="emits('update:currency', $event.target.value)"
     >
@@ -37,14 +37,35 @@ const emits = defineEmits(['update:currency'])
 
 .select-wrapper {
     position: relative;
+    padding-right: 10px;
 }
 
 .select-wrapper::after {
     content: "▼";
     font-size: 0.9rem;
-    top: 9px;
+    height: 100%;
     right: 10px;
     position: absolute;
     pointer-events: none;
+}
+
+.select-wrapper > *:last-child {
+  padding-right: 20px;
+}
+
+.selector {
+  background-color: transparent;
+  padding: 2px 10px;
+  margin: -2px -10px;
+  border-radius: 100px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba($color: #000000, $alpha: 0.1);
+  }
+
+  option {
+    @apply text-base
+  }
 }
 </style>

--- a/src/components/study/CurrencySelector.vue
+++ b/src/components/study/CurrencySelector.vue
@@ -1,22 +1,24 @@
 <template>
-  <select
-    class="border border-[#656565] text-[#868686] rounded-lg focus:ring-[#868686] focus:border-[#868686] block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-    v-model="selectedCurrency"
-    @change="emits('update:currency', $event.target.value)"
-  >
-    <option v-if="isCurrencySupported(localCurrency)" value="LOCAL">
-      {{ getCurrencyName(localCurrency) }} ({{ getCurrencySymbol(localCurrency) }})
-    </option>
-    <option v-else value="LOCAL">
-      {{ localCurrency }} ({{ getCurrencySymbol(localCurrency) }})
-    </option>
-    <option v-if="localCurrency !== 'USD' && isCurrencySupported(localCurrency)" value="USD">
-      {{ getCurrencyName('USD') }} ({{ getCurrencySymbol('USD') }})
-    </option>
-    <option v-if="localCurrency !== 'EUR' && isCurrencySupported(localCurrency)" value="EUR">
-      {{ getCurrencyName('EUR') }} ({{ getCurrencySymbol('EUR') }})
-    </option>
-  </select>
+  <div class="select-wrapper">
+    <select
+      class="border border-[#656565] text-[#868686] rounded-lg focus:ring-[#868686] focus:border-[#868686] block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+      v-model="selectedCurrency"
+      @change="emits('update:currency', $event.target.value)"
+    >
+      <option v-if="isCurrencySupported(localCurrency)" value="LOCAL">
+        {{ getCurrencyName(localCurrency) }} ({{ getCurrencySymbol(localCurrency) }})
+      </option>
+      <option v-else value="LOCAL">
+        {{ localCurrency }} ({{ getCurrencySymbol(localCurrency) }})
+      </option>
+      <option v-if="localCurrency !== 'USD' && isCurrencySupported(localCurrency)" value="USD">
+        {{ getCurrencyName('USD') }} ({{ getCurrencySymbol('USD') }})
+      </option>
+      <option v-if="localCurrency !== 'EUR' && isCurrencySupported(localCurrency)" value="EUR">
+        {{ getCurrencyName('EUR') }} ({{ getCurrencySymbol('EUR') }})
+      </option>
+    </select>
+  </div>
 </template>
 
 <script setup>
@@ -30,3 +32,19 @@ const props = defineProps({
 const selectedCurrency = ref(props.currency);
 const emits = defineEmits(['update:currency'])
 </script>
+
+<style lang="scss" scoped>
+
+.select-wrapper {
+    position: relative;
+}
+
+.select-wrapper::after {
+    content: "▼";
+    font-size: 0.9rem;
+    top: 9px;
+    right: 10px;
+    position: absolute;
+    pointer-events: none;
+}
+</style>

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -33,7 +33,7 @@
             />
             <div v-else>-</div>
           </div>
-            <div class="subtitle">Local currency</div>
+            <div class="subtitle">{{ currencySubtitle }}</div>
         </div>
         <div>
             <div class="title">{{ studyData.year }}</div>
@@ -47,6 +47,7 @@ import { computed } from 'vue'
 import { getCountry, getProduct, getStudy } from '@utils/data'
 import ComparisonLink from '@components/study/ComparisonLink.vue';
 import CurrencySelector from "./CurrencySelector.vue"
+import { getCurrencyName } from '@utils/currency.js'
 
 const props = defineProps({
     studyData: {
@@ -81,6 +82,14 @@ let dataToDisplay = computed(() => {
         result.country = props.studyData.country
     }
     return result
+})
+
+const currencySubtitle = computed(() => {
+  if (props.currency === "LOCAL") {
+     return "Local currency"
+  } else {
+    return `Converted from ${getCurrencyName(props.localCurrency)}`;
+  }
 })
 </script>
 

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -23,7 +23,16 @@
             <div class="subtitle">Country</div>
         </div>
         <div>
-            <div class="title">{{ studyData.targetCurrency ? getCurrencySymbol(studyData.targetCurrency) : '-'}}</div>
+          <div class="title">
+            <CurrencySelector
+              v-if="localCurrency"
+              class="title"
+              :currency="currency"
+              :localCurrency="localCurrency"
+              @update:currency="emits('update:currency', $event)"
+            />
+            <div v-else>-</div>
+          </div>
             <div class="subtitle">Local currency</div>
         </div>
         <div>
@@ -35,16 +44,20 @@
 
 <script setup>
 import { computed } from 'vue'
-import { getCurrencySymbol } from '@utils/currency.js'
 import { getCountry, getProduct, getStudy } from '@utils/data'
 import ComparisonLink from '@components/study/ComparisonLink.vue';
+import CurrencySelector from "./CurrencySelector.vue"
 
 const props = defineProps({
     studyData: {
       type: Object,
       required: true,
-    }
+    },
+    currency: String,
+    localCurrency: String
 })
+
+const emits = defineEmits(["update:currency"]);
 
 const commodityId = computed(() => {
     return getStudy(props.studyData.id).product;

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -22,18 +22,14 @@
             </div>
             <div class="subtitle">Country</div>
         </div>
-        <div>
-          <div class="title">
-            <CurrencySelector
-              v-if="localCurrency"
-              class="title"
-              :currency="currency"
-              :localCurrency="localCurrency"
-              @update:currency="emits('update:currency', $event)"
-            />
-            <div v-else>-</div>
-          </div>
-            <div class="subtitle">{{ currencySubtitle }}</div>
+        <div v-if="localCurrency">
+          <CurrencySelector
+            class="title"
+            :currency="currency"
+            :localCurrency="localCurrency"
+            @update:currency="emits('update:currency', $event)"
+          />
+          <div class="subtitle">{{ currencySubtitle }}</div>
         </div>
         <div>
             <div class="title">{{ studyData.year }}</div>

--- a/src/components/study/StudyMenu.vue
+++ b/src/components/study/StudyMenu.vue
@@ -26,30 +26,15 @@
         </a>
       </li>
     </ol>
-    <div v-if="localCurrency" class="mt-4 flex flex-col gap-1">
-      <div class="text-[#868686]">
-        Select currency {{ currency }}
-      </div>
-      <div class="max-w-[175px] text-[#868686] select-wrapper">
-        <CurrencySelector
-          :currency="currency"
-          :localCurrency="localCurrency"
-          @update:currency="emits('update:currency', $event)"
-        />
-      </div>
-    </div>
   </nav>
 </template>
 
 <script setup>
 import { defineEmits } from 'vue'
-import CurrencySelector from "./CurrencySelector.vue";
 
 const props = defineProps({
   views: Array,
   selectedViewKey: String,
-  localCurrency: String,
-  currency: String,
   fullReportPdfUrl: String
 })
 const emits = defineEmits(['select'])

--- a/src/components/study/StudyMenu.vue
+++ b/src/components/study/StudyMenu.vue
@@ -27,38 +27,24 @@
       </li>
     </ol>
     <div v-if="localCurrency" class="mt-4 flex flex-col gap-1">
-      <label for="select-currency" class="text-[#868686]">
-        Select currency {{ selectedCurrency }}
-      </label>
+      <div class="text-[#868686]">
+        Select currency {{ currency }}
+      </div>
       <div class="max-w-[175px] text-[#868686] select-wrapper">
-        <select
-          id="select-currency"
-          class="border border-[#656565] text-[#868686] rounded-lg focus:ring-[#868686] focus:border-[#868686] block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-          v-model="selectedCurrency"
-          @change="emits('update:currency', $event.target.value)"
-        >
-          <option v-if="isCurrencySupported(localCurrency)" value="LOCAL">
-            {{ getCurrencyName(localCurrency) }} ({{ getCurrencySymbol(localCurrency) }})
-          </option>
-          <option v-else value="LOCAL">
-            {{ localCurrency }} ({{ getCurrencySymbol(localCurrency) }})
-          </option>
-          <option v-if="localCurrency !== 'USD' && isCurrencySupported(localCurrency)" value="USD">
-            {{ getCurrencyName('USD') }} ({{ getCurrencySymbol('USD') }})
-          </option>
-          <option v-if="localCurrency !== 'EUR' && isCurrencySupported(localCurrency)" value="EUR">
-            {{ getCurrencyName('EUR') }} ({{ getCurrencySymbol('EUR') }})
-          </option>
-        </select>
+        <CurrencySelector
+          :currency="currency"
+          :localCurrency="localCurrency"
+          @update:currency="emits('update:currency', $event)"
+        />
       </div>
     </div>
   </nav>
 </template>
 
 <script setup>
-import { ref, defineEmits } from 'vue'
+import { defineEmits } from 'vue'
+import CurrencySelector from "./CurrencySelector.vue";
 
-import { getCurrencySymbol, getCurrencyName, isCurrencySupported } from '@utils/currency.js'
 const props = defineProps({
   views: Array,
   selectedViewKey: String,
@@ -67,7 +53,6 @@ const props = defineProps({
   fullReportPdfUrl: String
 })
 const emits = defineEmits(['select'])
-const selectedCurrency = ref(props.currency)
 </script>
 
 <style scoped lang="scss">

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -72,16 +72,3 @@ select {
     -webkit-appearance: none;
     appearance: none;
 }
-
-.select-wrapper {
-    position: relative;
-}
-
-.select-wrapper::after {
-    content: "▼";
-    font-size: 0.9rem;
-    top: 9px;
-    right: 10px;
-    position: absolute;
-    pointer-events: none;
-}

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -7,18 +7,20 @@
                 <div v-if="error" class="error">{{ error }}</div>
 
                 <div v-if="isDataLoaded">
-                    <StudyHeader :studyData="studyData"/>
+                    <StudyHeader
+                      :studyData="studyData"
+                      :localCurrency="studyData.targetCurrency" 
+                      :currency="$route.query.currency || 'LOCAL'"
+                      @update:currency="updateCurrency"
+                    />
                 </div>
             </header>
             <div class="w-full text-left my-16">
                 <StudyMenu 
                   v-if="isDataLoaded"
                   :views="views"
-                  :localCurrency="studyData.targetCurrency" 
-                  :currency="$route.query.currency || 'LOCAL'"
                   :selectedViewKey="view"
                   :fullReportPdfUrl="studyPdfUrls.fullReportPdfUrl"
-                  @update:currency="updateCurrency"
                   @select="selectView($event)"
                 />
             </div>


### PR DESCRIPTION
Resolves #58 

## Contexte

On veut pouvoir changer la devise depuis le header de l'étude, afin de rassembler les 2 endroits ou on parle de devise

- On met le selecteur dans le header
- On affiche l'info de devise locale lorsqu'elle est choisie

| Avant | Après |
| - | - |
| [Screencast from 2024-08-19 17-07-51.webm](https://github.com/user-attachments/assets/4bc14b70-2b5f-4e61-bf13-84111406ccef) | [Screencast from 2024-08-19 17-08-15.webm](https://github.com/user-attachments/assets/f2b93add-2c7f-45b6-b173-68fa95a807bd)|

## Modifications

- Extraction du selecteur
- Déplacement dans le header (branchement de la logique)
- Style pour s'inclure au header
- Ajout de l'info "Converted from ..." dans le sous-titre