### PR TITLE
fix(58): Keep currency in url query when navigating with section descriptions in overview

### DIFF
--- a/src/components/StudyOverview.vue
+++ b/src/components/StudyOverview.vue
@@ -13,7 +13,7 @@
       <div
         v-if="!!studyData.ecoData"
         class="section-link"
-        :to="'/study?id=' + studyData.id + '&view=economic-growth'"
+        @click="emits('select-view', 'economic-growth')"
       >
         <h3>Contribution to growth</h3>
         <p>
@@ -24,7 +24,7 @@
       <div
         v-if="!!studyData.ecoData"
         class="section-link"
-        :to="'/study?id=' + studyData.id + '&view=inclusiveness'"
+        @click="emits('select-view', 'inclusiveness')"
       >
         <h3>Inclusiveness</h3>
         <p>
@@ -34,7 +34,7 @@
       <div
         v-if="!!studyData.socialData"
         class="section-link"
-        :to="'/study?id=' + studyData.id + '&view=social-sustainability'"
+        @click="emits('select-view', 'social-sustainability')"
       >
         <h3>Social sustainability</h3>
         <p>
@@ -46,7 +46,7 @@
       <div
         v-if="!!studyData.acvData"
         class="section-link"
-        :to="'/study?id=' + studyData.id + '&view=environment'"
+        @click="emits('select-view', 'environment')"
       >
         <h3>Environmental sustainability</h3>
         <p>
@@ -73,6 +73,7 @@
 </template>
 
 <script setup>
+import { defineEmits } from "vue";
 import StagesDescription from '@/components/StagesDescription.vue'
 import SectionTitle from './typography/SectionTitle.vue'
 import PdfSection from './pdf/PdfSection.vue';
@@ -82,6 +83,7 @@ const props = defineProps({
   studyData: Object,
   studyPdfUrls: Object
 });
+const emits = defineEmits(["select-view"]);
 </script>
 
 <style scoped lang="scss">

--- a/src/components/StudyOverview.vue
+++ b/src/components/StudyOverview.vue
@@ -10,8 +10,9 @@
 
     <section v-if="studyData" class="explore">
       <h2>Explore up to 4 dimensions of the value chain</h2>
-      <RouterLink
+      <div
         v-if="!!studyData.ecoData"
+        class="section-link"
         :to="'/study?id=' + studyData.id + '&view=economic-growth'"
       >
         <h3>Contribution to growth</h3>
@@ -19,18 +20,20 @@
           Learn more about: Contribution to GDP, impact on Public Finances and Balance of Trade,
           Viability in the International Economy
         </p>
-      </RouterLink>
-      <RouterLink
+      </div>
+      <div
         v-if="!!studyData.ecoData"
+        class="section-link"
         :to="'/study?id=' + studyData.id + '&view=inclusiveness'"
       >
         <h3>Inclusiveness</h3>
         <p>
           Learn more about: Employment, Profit distribution among actors and impact of governance on income distribution
         </p>
-      </RouterLink>
-      <RouterLink
+      </div>
+      <div
         v-if="!!studyData.socialData"
+        class="section-link"
         :to="'/study?id=' + studyData.id + '&view=social-sustainability'"
       >
         <h3>Social sustainability</h3>
@@ -39,16 +42,17 @@
           <em>Gender equality</em>, <em>Food & nutrition security</em>, <em>Social capital</em> and
           <em>Living conditions</em>
         </p>
-      </RouterLink>
-      <RouterLink
+      </div>
+      <div
         v-if="!!studyData.acvData"
+        class="section-link"
         :to="'/study?id=' + studyData.id + '&view=environment'"
       >
         <h3>Environmental sustainability</h3>
         <p>
           Learn more about the value chain’s damages to Human Health, Ecosystem Quality, Natural Resources and Climate Change
         </p>
-      </RouterLink>
+      </div>
     </section>
 
     <PdfSection
@@ -69,8 +73,6 @@
 </template>
 
 <script setup>
-import { RouterLink } from 'vue-router'
-
 import StagesDescription from '@/components/StagesDescription.vue'
 import SectionTitle from './typography/SectionTitle.vue'
 import PdfSection from './pdf/PdfSection.vue';
@@ -85,10 +87,11 @@ const props = defineProps({
 <style scoped lang="scss">
 article {
   section.explore {
-    a {
+    .section-link {
       display: block;
       width: 100%;
       min-height: 6rem;
+      cursor: pointer;
 
       padding: 1rem;
       margin-bottom: 1rem;

--- a/src/components/comparison/ComparisonHeader.vue
+++ b/src/components/comparison/ComparisonHeader.vue
@@ -5,7 +5,7 @@
             <div class="study-box">
                 <div class="card-box">
                     <Card
-                        :link="getLink(study, 'LOCAL')"
+                        :link="getLink(study)"
                         :is-local="false"
                         :is-open="false"
                         :title="study.product.prettyName">

--- a/src/components/home/ByCategories.vue
+++ b/src/components/home/ByCategories.vue
@@ -6,7 +6,6 @@ const props = defineProps({
     categories: Array,
     studies: Array,
     countries: Array,
-    currency: String
 })
 
 const getStudiesByCategory = (studies, category) => {
@@ -35,7 +34,7 @@ const filterStudiesByCategory = (category) => {
     <section>
         <QuestionTitle>By <strong>product</strong></QuestionTitle>
         <template v-for="(category) in categories" :key="category.id">
-            <ByCategory :studies="filterStudiesByCategory(category.id)" :countries="countries" :category="category" :currency="currency"/>
+            <ByCategory :studies="filterStudiesByCategory(category.id)" :countries="countries" :category="category"/>
         </template>
     </section>
 </template>

--- a/src/components/home/ByCategory.vue
+++ b/src/components/home/ByCategory.vue
@@ -16,7 +16,6 @@ import SubCardsList from './SubCardsList.vue'
 const props = defineProps({
     studies: Array,
     countries: Array,
-    currency: String,
     category: Object
 })
 
@@ -52,7 +51,7 @@ const getStudiesByProduct = () => {
                 <li v-for="item in getStudiesByProduct()" :key="item.product">
                     <template v-if="item.studies.length === 1">
                         <Card
-                            :link="getLink(item.studies[0], currency)"
+                            :link="getLink(item.studies[0])"
                             :is-local="item.studies[0].local"
                             :title="getProduct(item.product).prettyName">
                             <template v-slot:logo>
@@ -82,7 +81,7 @@ const getStudiesByProduct = () => {
                                 :link="{ name: 'comparison', query: { studies: getStudyListQueryString(item.studies.map(study => study.id)) } }"
                                 :linkTitle="`Compare all ${item.product} studies`">
                                     <Card v-for="study in item.studies" :key="study.id"
-                                            :link="getLink(study, currency)"
+                                            :link="getLink(study)"
                                             :is-local="study.local"
                                             :title="getCountry(study.country)?.prettyName">
                                         <template v-slot:logo>

--- a/src/components/home/ByContinent.vue
+++ b/src/components/home/ByContinent.vue
@@ -16,7 +16,6 @@ const props = defineProps({
     continent: String,
     studies: Array,
     countries: Array,
-    currency: String
 })
 
 const CONTINENT_BG_COLORS = {
@@ -62,7 +61,7 @@ const getStudiesByCountry = () => {
             <li v-for="item in getStudiesByCountry()" :key="item.country">
                 <template v-if="item.studies.length === 1">
                     <Card 
-                        :link="getLink(item.studies[0], currency)"
+                        :link="getLink(item.studies[0])"
                         :is-local="item.studies[0].local"
                         :title="getCountry(item.country).prettyName">
                         <template v-slot:logo>
@@ -92,7 +91,7 @@ const getStudiesByCountry = () => {
                                 :link="{ name: 'comparison', query: { studies: getStudyListQueryString(item.studies.map(study => study.id)) } }"
                                 :linkTitle="`Compare all ${item.country} studies`">
                             <Card v-for="study in item.studies" :key="study.id"
-                                :link="getLink(study, currency)"
+                                :link="getLink(study)"
                                 :is-local="study.local"
                                 :title="getProduct(study.product).prettyName">
                                 <template v-slot:logo>

--- a/src/components/home/ByContinents.vue
+++ b/src/components/home/ByContinents.vue
@@ -8,7 +8,6 @@ const props = defineProps({
     categories: Array,
     studies: Array,
     countries: Array,
-    currency: String
 })
 
 const continents = computed(() => [...new Set(props.countries.map(country => country.continent))])
@@ -23,7 +22,7 @@ const getStudiesByContinent = (continent) => {
     <section>
         <QuestionTitle>By <strong>country</strong></QuestionTitle>
         <template v-for="continent in continents" :key="continent">
-            <ByContinent class="continent" :continent="continent" :studies="getStudiesByContinent(continent)" :countries="countries" :currency="currency"/>
+            <ByContinent class="continent" :continent="continent" :studies="getStudiesByContinent(continent)" :countries="countries"/>
         </template>
     </section>
 </template>

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,4 +1,4 @@
-export const getLink = (study, currency) => `/study?id=${study.local ? 'localStorage' : study.id}&currency=${currency}`
+export const getLink = (study) => `/study?id=${study.local ? 'localStorage' : study.id}`
 
 export function getStudyListQueryString(studyIds) {
     return studyIds.join(",");

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -39,8 +39,6 @@ async function populateStudiesData(jsonStudies) {
   }
 }
 
-const currency = computed(() => localStorage.getItem('currency') || 'LOCAL')
-
 const filteredStudies = computed(() => {
   return studies.value.filter(hasMandatoryParts);
 
@@ -132,10 +130,9 @@ function toggleFilter(filterKey) {
         :categories="categories"
         :studies="filteredStudies"
         :countries="countries"
-        :currency="currency"
       />
 
-      <ByContinents :studies="filteredStudies" :countries="countries" :currency="currency" />
+      <ByContinents :studies="filteredStudies" :countries="countries" />
     </section>
   </Skeleton>
 </template>

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -28,6 +28,7 @@
                   :studyData="studyData"
                   :studyPdfUrls="studyPdfUrls"
                   :currency="currencySymbol"
+                  @select-view="selectView($event)"
                 />
             </template>
         </div>


### PR DESCRIPTION
## Bug

A chaque fois qu'on navigue depuis le "Functional analysis" vers une page, on perd l'info de currency de l'url

![image](https://github.com/user-attachments/assets/003e3937-4721-4ca0-ab1c-104bcf2d3834)


## Fix

- Utilisation d'un evenement emit par StudyOverview afin de naviguer toujours avec `selectView` de `StudyView.vue`
- Petit refactor de `getLink` pour eviter des props inutiles dans la Home