### PR TITLE
fix: Default to local currency when we cannot convert it

### DIFF
--- a/src/components/study/CurrencySelector.vue
+++ b/src/components/study/CurrencySelector.vue
@@ -23,13 +23,18 @@
 
 <script setup>
 import { getCurrencySymbol, getCurrencyName, isCurrencySupported } from '@utils/currency.js'
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 
 const props = defineProps({
   localCurrency: String,
   currency: String,
 })
+
 const selectedCurrency = ref(props.currency);
+watch(() => props.currency, () => {
+  selectedCurrency.value = props.currency;
+});
+
 const emits = defineEmits(['update:currency'])
 </script>
 

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -49,6 +49,7 @@ import StudyHeader from '@components/study/StudyHeader.vue'
 import StudyMenu from '@components/study/StudyMenu.vue'
 import { getStudyData } from '@utils/data'
 import { getStudyPdfUrls } from '../utils/data'
+import { isCurrencySupported } from '@utils/currency.js'
 
 const route = useRoute();
 const router = useRouter()
@@ -134,10 +135,9 @@ function selectView(viewKey) {
 }
 
 onMounted(async () => {
-  setupCurrency()
-
   try {
     studyData.value = await getStudyData(route.query.id);
+    setupCurrency();
     studyPdfUrls.value = await getStudyPdfUrls(route.query.id);
   } catch(err) {
     error.value = err;
@@ -145,7 +145,9 @@ onMounted(async () => {
 })
 
 function setupCurrency() {
-  if (!route.query.currency) {
+  if (studyData.value && ! isCurrencySupported(studyData.value.targetCurrency)) {
+    updateCurrency("LOCAL");
+  } else if (!route.query.currency) {
     updateCurrency(localStorage.getItem('currency') || "LOCAL");
   }
 }

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -134,9 +134,7 @@ function selectView(viewKey) {
 }
 
 onMounted(async () => {
-  if (!route.query.currency) {
-    updateCurrency(localStorage.getItem('currency') || "LOCAL");
-  }
+  setupCurrency()
 
   try {
     studyData.value = await getStudyData(route.query.id);
@@ -145,6 +143,12 @@ onMounted(async () => {
     error.value = err;
   }
 })
+
+function setupCurrency() {
+  if (!route.query.currency) {
+    updateCurrency(localStorage.getItem('currency') || "LOCAL");
+  }
+}
 
 const isDataLoaded = computed(() => {
   return !! studyData.value && !! studyPdfUrls.value;


### PR DESCRIPTION
Resolves #80 

## Bug

Lorsqu'une currency n'est pas convertible, le selecteur ne s'affiche pas quand on a en cache (ou en url) USD / EUR

![image](https://github.com/user-attachments/assets/72c5ddf3-8cb6-435f-96ba-1fe897474a9b)


## Solution

On force à LOCAL si la currency locale n'est pas supportée.
