### PR TITLE
feat: Add expandable rows in the comparison

### DIFF
--- a/src/components/comparison/ComparisonEconomics.vue
+++ b/src/components/comparison/ComparisonEconomics.vue
@@ -11,16 +11,17 @@
       </template>
     </ComparisonRow>
 
-    <ComparisonRow 
+    <ComparisonExpandableRow
       :studies="studies" 
       title="Benefit/Cost ratio" 
       subtitle="-" 
       :get-value="study => study.metrics.eco.returnOnInvestment.benefitCostRatio"
+      :getSubValues="getBenefitCostRatioByStage"
     >
       <template #default="{ value }">
         <ComparisonDefaultCell :value="value" valueType="percent"/>
       </template>
-    </ComparisonRow>
+    </ComparisonExpandableRow>
   
     <ComparisonRow 
         :studies="studies" 
@@ -82,10 +83,22 @@
 import { getTotalAddedValue } from '@utils/economics.js'
 import ComparisonTitle from './ComparisonTitle.vue';
 import ComparisonRow from './ComparisonRow.vue';
+import ComparisonExpandableRow from './ComparisonExpandableRow.vue';
 import ComparisonDefaultCell from './ComparisonDefaultCell.vue';
 const props = defineProps({
     studies: Array,
 })
+
+function getBenefitCostRatioByStage(studyData) {
+  const stagesWithBenefit = studyData.metrics.eco.returnOnInvestment.stages
+    .filter(stage => stage.netOperatingProfits !== 0);
+
+  const benefitCostRatioByStage = {};
+  stagesWithBenefit.forEach(stage => {
+    benefitCostRatioByStage[stage.name] = stage.benefitCostRatio;
+  });
+  return benefitCostRatioByStage;
+}
 
 </script>
 

--- a/src/components/comparison/ComparisonEconomics.vue
+++ b/src/components/comparison/ComparisonEconomics.vue
@@ -10,6 +10,17 @@
         <ComparisonDefaultCell :value="value" valueType="number"/>
       </template>
     </ComparisonRow>
+
+    <ComparisonRow 
+      :studies="studies" 
+      title="Benefit/Cost ratio" 
+      subtitle="-" 
+      :get-value="study => study.metrics.eco.returnOnInvestment.benefitCostRatio"
+    >
+      <template #default="{ value }">
+        <ComparisonDefaultCell :value="value" valueType="percent"/>
+      </template>
+    </ComparisonRow>
   
     <ComparisonRow 
         :studies="studies" 

--- a/src/components/comparison/ComparisonExpandableRow.vue
+++ b/src/components/comparison/ComparisonExpandableRow.vue
@@ -28,6 +28,7 @@
 </template>
 
 <script setup>
+import _ from "lodash";
 import { computed, ref } from 'vue';
 import ComparisonRow from './ComparisonRow.vue';
 
@@ -43,7 +44,11 @@ const expanded = ref(false);
 function toggleExpand() {
   expanded.value = ! expanded.value;
 }
-const subKeys = computed(() => Object.keys(props.getSubValues(props.studies[0])))
+
+const subKeys = computed(() => {
+  const subValues = props.studies.map(props.getSubValues);
+  return _.union(...subValues.map(Object.keys));
+})
 </script>
 
 <style scoped lang="scss">

--- a/src/components/comparison/ComparisonSocial.vue
+++ b/src/components/comparison/ComparisonSocial.vue
@@ -1,11 +1,12 @@
 <template>
     <ComparisonTitle title="Social Sustainability" :studies="studies" />
-    <ComparisonRow
+    <ComparisonExpandableRow
       v-for="(part, index) in SOCIAL_PARTS"
       :studies="studies"
       :key="`part_${index}`"
       :title="part"
       :getValue="(study) => getOptionalSocialAverageGroup(study.socialData?.[index])"
+      :getSubValues="(study) => getSocialAverageSubGroups(study.socialData?.[index])"
     >
       <template #default="{ value }">
         <div class="tag-container mx-auto my-2">
@@ -17,7 +18,7 @@
           />
         </div>
       </template>
-    </ComparisonRow>
+    </ComparisonExpandableRow>
 </template>
 
 <script setup>
@@ -25,7 +26,7 @@
 import { getSocialAverageGroup } from '@utils/misc.js'
 import Tag from '@components/study/social-sustainability/Tag.vue';
 import ComparisonTitle from './ComparisonTitle.vue';
-import ComparisonRow from './ComparisonRow.vue';
+import ComparisonExpandableRow from './ComparisonExpandableRow.vue';
 const props = defineProps({
     studies: Array,
 })
@@ -58,6 +59,17 @@ function getOptionalSocialAverageGroup(socialImpact) {
   if (! socialImpact) { return null; }
 
   return getSocialAverageGroup(socialImpact)
+}
+
+function getSocialAverageSubGroups(socialImpact) {
+  if (! socialImpact) { return null; }
+
+  const socialAverageSubGroupsByName = {};
+  socialImpact.groups.forEach(group => {
+    const groupTitleWithoutNumber = group.title.slice(4);
+    socialAverageSubGroupsByName[groupTitleWithoutNumber] = Math.round(group.averageValue);
+  });
+  return socialAverageSubGroupsByName;
 }
 </script>
 

--- a/src/components/study/economic-growth/ReturnOnInvestment.vue
+++ b/src/components/study/economic-growth/ReturnOnInvestment.vue
@@ -52,11 +52,10 @@ const handleDataChartSeriesClick = (event) => {
 }
 
 const { prettyAmount, convertAmount } = useCurrencyUtils(props)
-const returnOnInvestmentData = computed(() => buildReturnOnInvestmentData(props.studyData));
 
 const populatedBarChartData = computed(() => {
   let tooltip = {}
-  const items = returnOnInvestmentData.value.stages.map((stage) => {
+  const items = props.studyData.metrics.eco.returnOnInvestment.stages.map((stage) => {
     if (!stage.netOperatingProfits) {
       return null
     }
@@ -84,7 +83,7 @@ const populatedBarChartData = computed(() => {
 })
 
 const currentStageReturnOnInvestmentData = computed(() => {
-  const currentStage = returnOnInvestmentData.value.stages.find(stage => stage.name === selectedStage.value);
+  const currentStage = props.studyData.metrics.eco.returnOnInvestment.stages.find(stage => stage.name === selectedStage.value);
   const currentStageActors = currentStage.actors;
   const tooltip = {}
   const items = currentStageActors.map((actor) => {
@@ -99,44 +98,6 @@ const currentStageReturnOnInvestmentData = computed(() => {
   return getMiniBarChart(items, tooltip, formatPercent, getColor(selectedStage.value))
 })
 
-function buildReturnOnInvestmentData(studyData) {
-  const stages = studyData.ecoData.stages;
-  const actors = studyData.ecoData.actors;
-
-  return {
-    stages: stages.map(stage => buildStageReturnOnInvestmentData(stage, actors))
-  }
-}
-function buildStageReturnOnInvestmentData(stage, actors) {
-  const stageActors = actors.filter((actor) => actor.stage === stage.name).map(buildActorReturnOnInvestmentData);
-
-  const netOperatingProfits = _.sumBy(stageActors, "netOperatingProfits");
-  const totalCosts = _.sumBy(stageActors, "totalCosts");
-
-  return {
-    name: stage.name,
-    actors: stageActors,
-    netOperatingProfits,
-    totalCosts,
-    benefitCostRatio: netOperatingProfits / totalCosts,
-  }
-}
-
-function buildActorReturnOnInvestmentData(actor) {
-  const netOperatingProfits = actor.netOperatingProfit || 0;
-  let totalCosts = actor.totalCosts;
-
-  if (actor.stage === 'Producers') {
-    totalCosts += netOperatingProfits;
-  }
-  return {
-    name: actor.name,
-    stage: actor.stage,
-    netOperatingProfits,
-    totalCosts,
-    benefitCostRatio: netOperatingProfits / totalCosts,
-  };
-}
 </script>
 
 <style scoped lang="scss">

--- a/src/components/study/economic-growth/ReturnOnInvestment.vue
+++ b/src/components/study/economic-growth/ReturnOnInvestment.vue
@@ -55,10 +55,9 @@ const { prettyAmount, convertAmount } = useCurrencyUtils(props)
 
 const populatedBarChartData = computed(() => {
   let tooltip = {}
-  const items = props.studyData.metrics.eco.returnOnInvestment.stages.map((stage) => {
-    if (!stage.netOperatingProfits) {
-      return null
-    }
+  const items = props.studyData.metrics.eco.returnOnInvestment.stages 
+  .filter(stage => stage.netOperatingProfits !== 0)
+  .map((stage) => {
     tooltip[stage.name] = `Net operating profit = ${prettyAmount.value(convertAmount.value(stage.netOperatingProfits))}<br>
           Total costs = ${prettyAmount.value(convertAmount.value(stage.totalCosts))}<br>
           Benefit/Cost Ratio = ${formatPercent(stage.benefitCostRatio)}`
@@ -67,7 +66,6 @@ const populatedBarChartData = computed(() => {
       value: stage.benefitCostRatio
     }
   })
-  .filter((item) => !!item)
 
   const ret = getSelectableBarChart(items, selectedStage.value, tooltip, formatPercent)
   return {

--- a/src/components/study/economic-growth/ReturnOnInvestment.vue
+++ b/src/components/study/economic-growth/ReturnOnInvestment.vue
@@ -60,22 +60,18 @@ const populatedBarChartData = computed(() => {
     .map((stage) => {
       const stageActors = actors.value.filter((actor) => actor.stage === stage.name)
 
-      const netOperatingProfits = convertAmount.value(
-        stageActors
+      const netOperatingProfits = stageActors
           .map((actor) => actor.netOperatingProfit || 0)
           .reduce((res, item) => res + item, 0)
-      )
-      let totalCosts = convertAmount.value(
-        stageActors.map((actor) => actor.totalCosts || 0).reduce((res, item) => res + item, 0)
-      )
+      let totalCosts = stageActors.map((actor) => actor.totalCosts || 0).reduce((res, item) => res + item, 0)
       if (stage.name === 'Producers') {
         totalCosts += netOperatingProfits
       }
       if (!netOperatingProfits) {
         return null
       }
-      tooltip[stage.name] = `Net operating profit = ${prettyAmount.value(netOperatingProfits)}<br>
-            Total costs = ${prettyAmount.value(totalCosts)}<br>
+      tooltip[stage.name] = `Net operating profit = ${prettyAmount.value(convertAmount.value(netOperatingProfits))}<br>
+            Total costs = ${prettyAmount.value(convertAmount.value(totalCosts))}<br>
             Benefit/Cost Ratio = ${formatPercent(netOperatingProfits / totalCosts)}`
       return {
         name: stage.name,
@@ -102,13 +98,13 @@ const currentStageReturnOnInvestmentData = computed(() => {
   const tooltip = {}
   const items = currentStageActors
     .map((actor) => {
-      const netOperatingProfits = convertAmount.value(actor.netOperatingProfit || 0)
-      let totalCosts = convertAmount.value(actor.totalCosts)
+      const netOperatingProfits = actor.netOperatingProfit || 0
+      let totalCosts = actor.totalCosts
       if (selectedStage.value === 'Producers') {
         totalCosts += netOperatingProfits
       }
-      tooltip[actor.name] = `Net operating profit = ${prettyAmount.value(netOperatingProfits)}<br>
-            Total costs = ${prettyAmount.value(totalCosts)}<br>
+      tooltip[actor.name] = `Net operating profit = ${prettyAmount.value(convertAmount.value(netOperatingProfits))}<br>
+            Total costs = ${prettyAmount.value(convertAmount.value(totalCosts))}<br>
             Benefit/Cost Ratio = ${formatPercent(netOperatingProfits / totalCosts)}`
       return {
         name: actor.name,

--- a/src/components/study/economic-growth/ReturnOnInvestment.vue
+++ b/src/components/study/economic-growth/ReturnOnInvestment.vue
@@ -79,14 +79,12 @@ const populatedBarChartData = computed(() => {
             Benefit/Cost Ratio = ${formatPercent(netOperatingProfits / totalCosts)}`
       return {
         name: stage.name,
-        value: (100 * netOperatingProfits) / totalCosts
+        value: netOperatingProfits / totalCosts
       }
     })
     .filter((item) => !!item)
 
-  const ret = getSelectableBarChart(items, selectedStage.value, tooltip, (value) =>
-    formatPercent(value / 100)
-  )
+  const ret = getSelectableBarChart(items, selectedStage.value, tooltip, formatPercent)
   return {
     ...ret,
     yAxis: {

--- a/src/utils/data/metrics/eco/returnOnInvestment.js
+++ b/src/utils/data/metrics/eco/returnOnInvestment.js
@@ -4,8 +4,10 @@ export function buildReturnOnInvestmentData(studyData) {
   const stages = studyData.ecoData.stages;
   const actors = studyData.ecoData.actors;
 
+  const stagesData = stages.map(stage => buildStageReturnOnInvestmentData(stage, actors))
   return {
-    stages: stages.map(stage => buildStageReturnOnInvestmentData(stage, actors))
+    benefitCostRatio: buildStudyBenefitCostRatio(stagesData),
+    stages: stagesData
   }
 }
 
@@ -22,6 +24,13 @@ function buildStageReturnOnInvestmentData(stage, actors) {
     totalCosts,
     benefitCostRatio: netOperatingProfits / totalCosts,
   }
+}
+
+function buildStudyBenefitCostRatio(stagesData) {
+  const netOperatingProfits = _.sumBy(stagesData, "netOperatingProfits");
+  const totalCosts = _.sumBy(stagesData, "totalCosts");
+
+  return netOperatingProfits / totalCosts;
 }
 
 function buildActorReturnOnInvestmentData(actor) {

--- a/src/utils/data/metrics/eco/returnOnInvestment.js
+++ b/src/utils/data/metrics/eco/returnOnInvestment.js
@@ -1,0 +1,41 @@
+import _ from "lodash";
+
+export function buildReturnOnInvestmentData(studyData) {
+  const stages = studyData.ecoData.stages;
+  const actors = studyData.ecoData.actors;
+
+  return {
+    stages: stages.map(stage => buildStageReturnOnInvestmentData(stage, actors))
+  }
+}
+
+function buildStageReturnOnInvestmentData(stage, actors) {
+  const stageActors = actors.filter((actor) => actor.stage === stage.name).map(buildActorReturnOnInvestmentData);
+
+  const netOperatingProfits = _.sumBy(stageActors, "netOperatingProfits");
+  const totalCosts = _.sumBy(stageActors, "totalCosts");
+
+  return {
+    name: stage.name,
+    actors: stageActors,
+    netOperatingProfits,
+    totalCosts,
+    benefitCostRatio: netOperatingProfits / totalCosts,
+  }
+}
+
+function buildActorReturnOnInvestmentData(actor) {
+  const netOperatingProfits = actor.netOperatingProfit || 0;
+  let totalCosts = actor.totalCosts;
+
+  if (actor.stage === 'Producers') {
+    totalCosts += netOperatingProfits;
+  }
+  return {
+    name: actor.name,
+    stage: actor.stage,
+    netOperatingProfits,
+    totalCosts,
+    benefitCostRatio: netOperatingProfits / totalCosts,
+  };
+}

--- a/src/utils/data/metrics/index.js
+++ b/src/utils/data/metrics/index.js
@@ -1,0 +1,9 @@
+import { buildReturnOnInvestmentData } from "./eco/returnOnInvestment";
+
+export function computeMetrics(studyData) {
+  return {
+    eco: {
+      returnOnInvestment: buildReturnOnInvestmentData(studyData)
+    }
+  }
+}

--- a/src/utils/data/studyData.js
+++ b/src/utils/data/studyData.js
@@ -1,5 +1,6 @@
 import { json } from 'd3-fetch'
 export const LOCAL_STORAGE_ID = 'localStorage'
+import { computeMetrics } from "./metrics";
 
 const cachedDataByStudyId = {};
 
@@ -14,23 +15,27 @@ export const getStudyData = async (studyId) => {
 async function fetchCachedStudyData(studyId) {
   if (cachedDataByStudyId[studyId]) { return cachedDataByStudyId[studyId]; }
 
-  const data = await fetchedStudyData(studyId);
+  const data = await fetchedPopulatedStudyData(studyId);
   cachedDataByStudyId[studyId] = data;
   return data;
 }
 
-async function fetchedStudyData(studyId) {
+async function fetchedPopulatedStudyData(studyId) {
   let rawEcoData = await getStudyDataFromFileName(studyId, "eco")
   let rawSocialData = await getStudyDataFromFileName(studyId, "social")
   let rawAcvData = await getStudyDataFromFileName(studyId, "acv")
 
   const metaInfo = rawEcoData ? rawEcoData : rawSocialData ? rawSocialData : rawAcvData;
-  return {
+  const rawData = {
       ...metaInfo,
       ecoData: rawEcoData?.ecoData,
       socialData: rawSocialData?.socialData,
       acvData: rawAcvData?.acvData
   };
+  return {
+    ...rawData,
+    metrics: computeMetrics(rawData)
+  }
 }
 
 async function getStudyDataFromFileName(studyId, studyPart) {


### PR DESCRIPTION
Issue: #67

## Contexte

On veut afficher plus de données dans la page de comparaison grace a un menu déroulant

- Le ratio Benefice/couts (avec un dropdown par `stage`
- On veut également avoir des dropdown avec tous les sous-aspects sociaux

Screenshot (style non final)

[Screencast from 2024-08-21 15-40-03.webm](https://github.com/user-attachments/assets/bf54eb05-8a43-4eec-b40f-14a91f0ba251)


## Plan de PRs

- [85](https://github.com/leonarf/VCA4D/pull/85) Création d'un composant pour le dropdown
- À merger simulatanément
  - :dart: **Cette PR**: Ajout des données
  - Améliorer le style de ces dropdowns

## Commits

- Un long refacto afin d'extraire l'accès aux couts/bénéfices et au calcul du ROI de `ReturnOnInvestment`
  - Extraction dans une fonction (plusieurs commits)
  - Chargement de ces données dès qu'on charge l'étude
- Ajout des menus déroulant avec `ComparisonExpandableRow`
  - :warning: On calcule le ROI total de la filière en faisant la somme des couts et la somme des profits, mais c'est peut etre une mauvaise idée. :thinking: Cf discussion ci dessous.