### PR TITLE
feat(67): Better style for the expandable rows

### DIFF
--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -44,5 +44,12 @@ const emit = defineEmits(["select-studies"]);
     tr td:not(:first-child):not(:last-child):not(:nth-last-child(2)) {
       @apply border-r-2
     }
+
+    tr td:first-child >*:first-child {
+      margin-left: 5px;
+    }
+    tr td:nth-last-child(2) > *:last-child {
+      margin-right: 5px;
+    }
 }
 </style>

--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -19,7 +19,6 @@
 </template>
 
 <script setup>
-
 import ComparisonHeader from '@components/comparison/ComparisonHeader.vue'
 import ComparisonSocial from '@components/comparison/ComparisonSocial.vue'
 import ComparisonSeparator from '@components/comparison/ComparisonSeparator.vue'
@@ -37,8 +36,8 @@ const emit = defineEmits(["select-studies"]);
     td {
         box-sizing: border-box;
     }
-    td {
-        @apply w-1/5
+    td:not(:first-child) {
+        min-width: 20%;
     }
 
     tr td:not(:first-child):not(:last-child):not(:nth-last-child(2)) {

--- a/src/components/comparison/ComparisonExpandableRow.vue
+++ b/src/components/comparison/ComparisonExpandableRow.vue
@@ -74,17 +74,20 @@ const subKeys = computed(() => Object.keys(props.getSubValues(props.studies[0]))
       @include border-radius-bottom;
     }
   
-    &:hover :deep(td:not(:last-child)) {
-      background-color: #A4CAFE;
+    &:hover, &.expanded {
+      :deep(td:not(:last-child)) {
+        background-color: #E5E7EB;
+      }
     }
+
     &.expanded:not(:hover) :deep(td:not(:last-child)) {
-      background-color: #C3DDFD;
+      background-color: #E5E7EB;
     }
   }
 
   .sub-row {
     :deep(td:not(:last-child)) {
-      background-color: #E1EFFE;
+      background-color: #F3F4F6;
     }
 
     &:not(.expanded) {

--- a/src/components/comparison/ComparisonExpandableRow.vue
+++ b/src/components/comparison/ComparisonExpandableRow.vue
@@ -15,10 +15,10 @@
     </template>
   </ComparisonRow>
   <ComparisonRow
-    v-for="subKey in subKeys"
+    v-for="(subKey, index) in subKeys"
     :studies="studies"
     class="sub-row"
-    :class="{ expanded }"
+    :class="{ expanded, 'last-sub-row': index === subKeys.length - 1 }"
     :title="subKey"
     subtitle="-"
     :getValue="study => getSubValues(study)[subKey]"
@@ -49,8 +49,31 @@ const subKeys = computed(() => Object.keys(props.getSubValues(props.studies[0]))
 </script>
 
 <style scoped lang="scss">
+  $border-radius: 6px;
+  @mixin border-radius-bottom {
+    :deep(td:first-child) {
+      border-bottom-left-radius: $border-radius;
+    }
+    :deep(td:nth-last-child(2)) {
+      border-bottom-right-radius: $border-radius;
+    }
+  }
+  @mixin border-radius-top {
+    :deep(td:first-child) {
+      border-top-left-radius: $border-radius;
+    }
+    :deep(td:nth-last-child(2)) {
+      border-top-right-radius: $border-radius;
+    }
+  }
 
-  .parent-row {    
+  .parent-row {
+    @include border-radius-top;
+    
+    &:not(.expanded) {
+      @include border-radius-bottom;
+    }
+  
     &:hover :deep(td:not(:last-child)) {
       background-color: #A4CAFE;
     }
@@ -67,5 +90,9 @@ const subKeys = computed(() => Object.keys(props.getSubValues(props.studies[0]))
     &:not(.expanded) {
       display: none;
     }
+  }
+
+  .last-sub-row {
+    @include border-radius-bottom;
   }
 </style>

--- a/src/components/comparison/ComparisonExpandableRow.vue
+++ b/src/components/comparison/ComparisonExpandableRow.vue
@@ -1,5 +1,7 @@
 <template>
   <ComparisonRow
+    class="parent-row"
+    :class="{ expanded }"
     :studies="studies"
     :title="title"
     :subtitle="subtitle"
@@ -47,9 +49,19 @@ const subKeys = computed(() => Object.keys(props.getSubValues(props.studies[0]))
 </script>
 
 <style scoped lang="scss">
+
+  .parent-row {    
+    &:hover :deep(td:not(:last-child)) {
+      background-color: #A4CAFE;
+    }
+    &.expanded:not(:hover) :deep(td:not(:last-child)) {
+      background-color: #C3DDFD;
+    }
+  }
+
   .sub-row {
     :deep(td:not(:last-child)) {
-      background-color: #E5E7EB;
+      background-color: #E1EFFE;
     }
 
     &:not(.expanded) {

--- a/src/components/comparison/ComparisonRow.vue
+++ b/src/components/comparison/ComparisonRow.vue
@@ -53,9 +53,5 @@ const values = computed(() => props.studies.map(study => props.getValue(study)))
 
   .expandable {
     cursor: pointer;
-
-    &:hover td:not(:last-child) {
-      background-color: #F3F4F6;
-    }
   }
 </style>

--- a/src/components/comparison/ComparisonRow.vue
+++ b/src/components/comparison/ComparisonRow.vue
@@ -1,10 +1,10 @@
 <template>
-  <tr :class="{ expandable }" @click="emits('toggle-expand')">
+  <tr class="row" :class="{ expandable }" @click="emits('toggle-expand')">
       <td class="row-header">
           <div>
             <div>
               {{ title }}
-              <span v-if="expandable">{{ expanded ? "▲" : "▼" }}</span>
+              <span v-if="expandable" class="expand-arrow">{{ expanded ? "▲" : "▼" }}</span>
             </div>
             <div class="definition">{{ subtitle }}</div>
           </div>
@@ -58,5 +58,8 @@ const values = computed(() => props.studies.map(study => props.getValue(study)))
 
   .expandable {
     cursor: pointer;
+  }
+  .row:hover .expand-arrow {
+    color: #3F83F8;
   }
 </style>

--- a/src/components/comparison/ComparisonRow.vue
+++ b/src/components/comparison/ComparisonRow.vue
@@ -1,11 +1,13 @@
 <template>
   <tr :class="{ expandable }" @click="emits('toggle-expand')">
-      <td class="row-label">
+      <td class="row-header">
           <div>
-            <div>{{ title }}</div>
+            <div>
+              {{ title }}
+              <span v-if="expandable">{{ expanded ? "▲" : "▼" }}</span>
+            </div>
             <div class="definition">{{ subtitle }}</div>
           </div>
-          <div v-if="expandable">{{ expanded ? "▲" : "▼" }}</div>
       </td>
       <td v-for="(study, index) in studies" :key="`value_added__${study.id}`">
         <slot :value="values[index]"></slot>
@@ -31,13 +33,16 @@ const values = computed(() => props.studies.map(study => props.getValue(study)))
 </script>
 
 <style scoped lang="scss">
-  .row-label {
+  .row-header {
     min-width: 220px;
     padding-right: 20px;
     display: flex;
     align-items: start;
+    gap: 10px;
   }
+
   .definition {
+    min-height: 24px;
     @apply text-[#9B9B9B] italic
   }
   


### PR DESCRIPTION
Issue: #67

## Contexte

On veut afficher plus de données dans la page de comparaison grace a un menu déroulant

- Le ratio Benefice/couts (avec un dropdown par `stage`
- On veut également avoir des dropdown avec tous les sous-aspects sociaux

## Plan de PRs

- [85](https://github.com/leonarf/VCA4D/pull/85) Création d'un composant pour le dropdown
- À merger simulatanément
  - [88](https://github.com/leonarf/VCA4D/pull/88) Ajout des données
  - :dart: **Cette PR**: Améliorer le style de ces dropdowns
  
## Commits

| Avant | Après |
| - | - |
| [Screencast from 2024-08-21 16-56-25.webm](https://github.com/user-attachments/assets/53bc2dbe-67f6-4b0d-a8fb-3509c365924d) | [Screencast from 2024-08-21 16-54-13.webm](https://github.com/user-attachments/assets/b95cb3c3-06ba-42c9-86e3-2d713443e0dd) |



- Changements des couleurs de background 
- Fixs pour que ces backgrounds aient l'air d'un bloc
- Ajout de bord arrondis