### PR TITLE
fix(67): Don't compute eco metrics if there's no ecoData

### DIFF
--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -36,15 +36,16 @@ const emit = defineEmits(["select-studies"]);
     td {
         box-sizing: border-box;
     }
-    td:not(:first-child) {
+    td {
         min-width: 20%;
     }
 
     tr td:not(:first-child):not(:last-child):not(:nth-last-child(2)) {
-      @apply border-r-2
+      @apply border-r-2;
+      border-right-color: #D1D5DB;
     }
 
-    tr td:first-child >*:first-child {
+    tr td:first-child > * {
       margin-left: 5px;
     }
     tr td:nth-last-child(2) > *:last-child {

--- a/src/components/comparison/ComparisonEconomics.vue
+++ b/src/components/comparison/ComparisonEconomics.vue
@@ -15,7 +15,7 @@
       :studies="studies" 
       title="Benefit/Cost ratio" 
       subtitle="-" 
-      :get-value="study => study.metrics.eco.returnOnInvestment.benefitCostRatio"
+      :get-value="study => study.metrics.eco?.returnOnInvestment.benefitCostRatio"
       :getSubValues="getBenefitCostRatioByStage"
     >
       <template #default="{ value }">
@@ -90,7 +90,8 @@ const props = defineProps({
 })
 
 function getBenefitCostRatioByStage(studyData) {
-  const stagesWithBenefit = studyData.metrics.eco.returnOnInvestment.stages
+  if (! studyData.metrics.eco) { return {}; }
+  const stagesWithBenefit = studyData.metrics.eco?.returnOnInvestment.stages
     .filter(stage => stage.netOperatingProfits !== 0);
 
   const benefitCostRatioByStage = {};

--- a/src/components/comparison/ComparisonExpandableRow.vue
+++ b/src/components/comparison/ComparisonExpandableRow.vue
@@ -1,12 +1,11 @@
 <template>
   <ComparisonRow
-    class="parent-row"
-    :class="{ expanded }"
+    :class="{ expanded, 'parent-row': hasSubKeys }"
     :studies="studies"
     :title="title"
     :subtitle="subtitle"
     :getValue="getValue"
-    expandable
+    :expandable="hasSubKeys"
     :expanded="expanded"
     @toggle-expand="toggleExpand()"
   >
@@ -50,7 +49,9 @@ function toggleExpand() {
 const subKeys = computed(() => {
   const subValues = props.studies.map(props.getSubValues);
   return _.union(...subValues.map(Object.keys));
-})
+});
+
+const hasSubKeys = computed(() => subKeys.value.length !== 0);
 </script>
 
 <style scoped lang="scss">

--- a/src/components/comparison/ComparisonExpandableRow.vue
+++ b/src/components/comparison/ComparisonExpandableRow.vue
@@ -19,7 +19,6 @@
     class="sub-row"
     :class="{ expanded, 'last-sub-row': index === subKeys.length - 1 }"
     :title="subKey"
-    subtitle="-"
     :getValue="study => getSubValues(study)[subKey]"
   >
     <template #default="{ value }">

--- a/src/components/comparison/ComparisonRow.vue
+++ b/src/components/comparison/ComparisonRow.vue
@@ -1,13 +1,11 @@
 <template>
   <tr class="row" :class="{ expandable }" @click="emits('toggle-expand')">
       <td class="row-header">
-          <div>
-            <div>
-              {{ title }}
-              <span v-if="expandable" class="expand-arrow">{{ expanded ? "▲" : "▼" }}</span>
-            </div>
-            <div class="definition">{{ subtitle }}</div>
-          </div>
+        <div>
+          {{ title }}
+          <span v-if="expandable" class="expand-arrow">{{ expanded ? "▲" : "▼" }}</span>
+        </div>
+        <div v-if="subtitle" class="definition">{{ subtitle }}</div>
       </td>
       <td v-for="(study, index) in studies" :key="`value_added__${study.id}`">
         <slot :value="values[index]"></slot>
@@ -34,11 +32,12 @@ const values = computed(() => props.studies.map(study => props.getValue(study)))
 
 <style scoped lang="scss">
   .row-header {
-    min-width: 220px;
+    min-width: 250px;
+    min-height: 50px;
     padding-right: 20px;
     display: flex;
-    align-items: start;
-    gap: 10px;
+    flex-direction: column;
+    justify-content: center;
   }
 
   .definition {

--- a/src/utils/data/metrics/eco/returnOnInvestment.js
+++ b/src/utils/data/metrics/eco/returnOnInvestment.js
@@ -1,8 +1,8 @@
 import _ from "lodash";
 
-export function buildReturnOnInvestmentData(studyData) {
-  const stages = studyData.ecoData.stages;
-  const actors = studyData.ecoData.actors;
+export function buildReturnOnInvestmentData(ecoData) {
+  const stages = ecoData.stages;
+  const actors = ecoData.actors;
 
   const stagesData = stages.map(stage => buildStageReturnOnInvestmentData(stage, actors))
   return {

--- a/src/utils/data/metrics/index.js
+++ b/src/utils/data/metrics/index.js
@@ -2,8 +2,14 @@ import { buildReturnOnInvestmentData } from "./eco/returnOnInvestment";
 
 export function computeMetrics(studyData) {
   return {
-    eco: {
-      returnOnInvestment: buildReturnOnInvestmentData(studyData)
-    }
+    eco: buildEcoMetrics(studyData)
   }
+}
+
+function buildEcoMetrics(studyData) {
+  if (! studyData.ecoData) { return null; }
+
+  return {
+    returnOnInvestment: buildReturnOnInvestmentData(studyData.ecoData)
+  };
 }


### PR DESCRIPTION
Issue: #67

## Contexte

Suite à #88 , on calculait des métrique eco au chargement d'une étude, meme si elle n'avait pas de données éco ! Cela fait crasher la popup de la page de comparaison.

## Fix

- Ne pas populate les métriques `eco` si `ecoData` n'est pas défini
- [Bonus] Ne pas afficher le dropdown s'il n'y a aucune sous-donnée
- [Bonus] Un peu de styling en plus pour peaufiner le dropdown