### PR TITLE
feat(74): Display conversion info when converting the local currency

### DIFF
--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="header">
         <div>
-            <div class="title">
+            <div class="header-title">
               {{ commodityName }}
               <ComparisonLink
                 class="link"
@@ -12,7 +12,7 @@
             <div class="subtitle">Commodity</div>
         </div>
         <div>
-            <div class="title">
+            <div class="header-title">
               {{ dataToDisplay.country }}
               <ComparisonLink
                 class="link"
@@ -24,7 +24,7 @@
         </div>
         <div v-if="localCurrency">
           <CurrencySelector
-            class="title"
+            class="header-title"
             :currency="currency"
             :localCurrency="localCurrency"
             @update:currency="emits('update:currency', $event)"
@@ -38,7 +38,7 @@
           </div>
         </div>
         <div>
-            <div class="title">{{ studyData.year }}</div>
+            <div class="header-title">{{ studyData.year }}</div>
             <div class="subtitle">Reference year</div>
         </div>
     </div>
@@ -114,7 +114,7 @@ const currencySubtitle = computed(() => {
         gap: 5px;
         align-items: center;
     }
-    .title {
+    .header-title {
         @apply text-[#303030] text-3xl font-thin;
         display: flex;
         align-items: flex-end;

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -29,7 +29,13 @@
             :localCurrency="localCurrency"
             @update:currency="emits('update:currency', $event)"
           />
-          <div class="subtitle">{{ currencySubtitle }}</div>
+          <div class="subtitle">
+            {{ currencySubtitle }}
+            <InfoTooltip
+              v-if="currency !== 'LOCAL'"
+              text="Using the World Bank's currency rates for the reference year"
+            />
+          </div>
         </div>
         <div>
             <div class="title">{{ studyData.year }}</div>
@@ -42,6 +48,7 @@
 import { computed } from 'vue'
 import { getCountry, getProduct, getStudy } from '@utils/data'
 import ComparisonLink from '@components/study/ComparisonLink.vue';
+import InfoTooltip from '@components/typography/InfoTooltip.vue';
 import CurrencySelector from "./CurrencySelector.vue"
 import { getCurrencyName } from '@utils/currency.js'
 
@@ -102,6 +109,10 @@ const currencySubtitle = computed(() => {
 
     .subtitle {
         @apply text-[#656565] text-xs;
+
+        display: flex;
+        gap: 5px;
+        align-items: center;
     }
     .title {
         @apply text-[#303030] text-3xl font-thin;

--- a/src/components/typography/InfoTooltip.vue
+++ b/src/components/typography/InfoTooltip.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <Svg
+      class="question-mark"
+      :svg="QuestionMark"
+    />
+    <Tooltip
+      :contenu="text"
+      :options="{ placement: 'right', maxWidth: 350 }"
+    />
+  </div>
+</template>
+
+<script setup>
+import Tooltip from "@components/Tooltip.vue";
+import Svg from "@components/Svg.vue";
+import QuestionMark from '../../images/icons/info-question.svg'
+
+const props = defineProps({
+  text: String,
+})
+</script>
+
+<style scoped lang="scss">
+  .question-mark {
+    height: 1em;
+  }
+</style>

--- a/src/components/typography/NiceMetric.vue
+++ b/src/components/typography/NiceMetric.vue
@@ -7,25 +7,16 @@
           <div class="label">
             {{ label }}
           </div>
-          <div v-if="description">
-            <Svg
-              class="description-logo"
-              :svg="QuestionMark"
-            />
-            <Tooltip
-              class="tooltip"
-              :contenu="description"
-              :options="{ placement: 'right', maxWidth: 350 }"
-            />
-          </div>
+          <InfoTooltip
+            v-if="description"
+            :text="description"
+          />
         </div>
     </div>
 </template>
 
 <script setup>
-import Tooltip from "@components/Tooltip.vue";
-import Svg from "@components/Svg.vue";
-import QuestionMark from '../../images/icons/info-question.svg'
+import InfoTooltip from "@components/typography/InfoTooltip.vue";
 import { computed } from "vue";
 
 const props = defineProps({
@@ -58,12 +49,6 @@ const displayedValue = computed(() => {
       font-size: 1rem;
       line-height: 1.5rem;
       text-transform: uppercase;
-    }
-    .description-logo {
-      width: 0.9rem;
-    }
-    .tooltip {
-      text-transform: none;
     }
   }
 </style>


### PR DESCRIPTION
Resolves #74

## Contexte

On ajoute un tooltip expliquant qu'on utilise les taux de la banque mondiale
![image](https://github.com/user-attachments/assets/c14213b7-eb29-488e-a377-4ce853dea029)


## COmmits

- Factorisation du tooltip sur une icone `?` (utilisé dans `NiceMetric`)
- Ajout dans le Conversion Selector
