### PR TITLE
feedback(67): Handle Gaspard's feedback

### DIFF
--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -32,11 +32,12 @@ const emit = defineEmits(["select-studies"]);
 </script>
 
 <style lang="scss" scoped>
-:deep(*) {
+  table {
+    margin: 0 -15px;
+  }
+  :deep(*) {
     td {
         box-sizing: border-box;
-    }
-    td {
         min-width: 20%;
     }
 
@@ -46,10 +47,10 @@ const emit = defineEmits(["select-studies"]);
     }
 
     tr td:first-child > * {
-      margin-left: 5px;
+      margin-left: 15px;
     }
     tr td:nth-last-child(2) > *:last-child {
-      margin-right: 5px;
+      margin-right: 15px;
     }
-}
+  }
 </style>

--- a/src/components/StudyEconomicGrowth.vue
+++ b/src/components/StudyEconomicGrowth.vue
@@ -11,7 +11,7 @@
       It also assesses its <strong>viability</strong> within the global economy.  
     </p>
 
-    <ReturnOnInvestment :studyData="studyData" :currency="currency"/>
+    <BenefitCostRatio :studyData="studyData" :currency="currency"/>
     <AddedValue :studyData="studyData" :currency="currency"/>
     <PublicFinances :studyData="studyData" :currency="currency"/>
       
@@ -23,7 +23,7 @@
 </template>
 
 <script setup>
-import ReturnOnInvestment from './study/economic-growth/ReturnOnInvestment.vue'
+import BenefitCostRatio from './study/economic-growth/BenefitCostRatio.vue'
 import AddedValue from './study/economic-growth/AddedValue.vue'
 import PublicFinances from './study/economic-growth/PublicFinances.vue'
 import SectionTitle from '@typography/SectionTitle.vue'

--- a/src/components/comparison/ComparisonEconomics.vue
+++ b/src/components/comparison/ComparisonEconomics.vue
@@ -15,7 +15,7 @@
       :studies="studies" 
       title="Benefit/Cost ratio" 
       subtitle="-" 
-      :get-value="study => study.metrics.eco?.returnOnInvestment.benefitCostRatio"
+      :get-value="study => study.metrics.eco?.benefitCostRatio.benefitCostRatio"
       :getSubValues="getBenefitCostRatioByStage"
     >
       <template #default="{ value }">
@@ -91,7 +91,7 @@ const props = defineProps({
 
 function getBenefitCostRatioByStage(studyData) {
   if (! studyData.metrics.eco) { return {}; }
-  const stagesWithBenefit = studyData.metrics.eco?.returnOnInvestment.stages
+  const stagesWithBenefit = studyData.metrics.eco?.benefitCostRatio.stages
     .filter(stage => stage.netOperatingProfits !== 0);
 
   const benefitCostRatioByStage = {};

--- a/src/components/comparison/ComparisonExpandableRow.vue
+++ b/src/components/comparison/ComparisonExpandableRow.vue
@@ -80,13 +80,10 @@ const hasSubKeys = computed(() => subKeys.value.length !== 0);
     }
   
     &:hover, &.expanded {
+      font-weight: 600;
       :deep(td:not(:last-child)) {
         background-color: #E5E7EB;
       }
-    }
-
-    &.expanded:not(:hover) :deep(td:not(:last-child)) {
-      background-color: #E5E7EB;
     }
   }
 

--- a/src/components/comparison/ComparisonRow.vue
+++ b/src/components/comparison/ComparisonRow.vue
@@ -1,7 +1,7 @@
 <template>
   <tr class="row" :class="{ expandable }" @click="emits('toggle-expand')">
       <td class="row-header">
-        <div>
+        <div class="row-title">
           {{ title }}
           <span v-if="expandable" class="expand-arrow">{{ expanded ? "▲" : "▼" }}</span>
         </div>
@@ -57,8 +57,5 @@ const values = computed(() => props.studies.map(study => props.getValue(study)))
 
   .expandable {
     cursor: pointer;
-  }
-  .row:hover .expand-arrow {
-    color: #3F83F8;
   }
 </style>

--- a/src/components/comparison/ComparisonTitle.vue
+++ b/src/components/comparison/ComparisonTitle.vue
@@ -1,7 +1,9 @@
 <template>
     <tr>
-        <td class="title">
-            {{ title }}
+        <td class="comparison-title">
+            <div>
+              {{ title }}
+            </div>
         </td>
         <td v-for="study in studies" :key="`${study.id}`">
             
@@ -19,7 +21,7 @@ const props = defineProps({
 </script>
 
 <style lang="scss">
-  .title {
+  .comparison-title {
     @apply uppercase text-[#8A8A8A] font-bold text-sm pb-4;
   }
 </style>

--- a/src/components/study/economic-growth/BenefitCostRatio.vue
+++ b/src/components/study/economic-growth/BenefitCostRatio.vue
@@ -13,7 +13,7 @@
       <MiniChartContainer :currentStage="selectedStage" title="Benefit/Cost Ratio (%)">
         <div class="flex flex-row w-full justify-evenly mt-6">
           <div class="w-full flex flex-row justify-center">
-            <Ring :options="currentStageReturnOnInvestmentData"></Ring>
+            <Ring :options="currentStageBenefitCostRatioData"></Ring>
           </div>
         </div>
       </MiniChartContainer>
@@ -55,7 +55,7 @@ const { prettyAmount, convertAmount } = useCurrencyUtils(props)
 
 const populatedBarChartData = computed(() => {
   let tooltip = {}
-  const items = props.studyData.metrics.eco.returnOnInvestment.stages 
+  const items = props.studyData.metrics.eco.benefitCostRatio.stages 
   .filter(stage => stage.netOperatingProfits !== 0)
   .map((stage) => {
     tooltip[stage.name] = `Net operating profit = ${prettyAmount.value(convertAmount.value(stage.netOperatingProfits))}<br>
@@ -80,8 +80,8 @@ const populatedBarChartData = computed(() => {
   }
 })
 
-const currentStageReturnOnInvestmentData = computed(() => {
-  const currentStage = props.studyData.metrics.eco.returnOnInvestment.stages.find(stage => stage.name === selectedStage.value);
+const currentStageBenefitCostRatioData = computed(() => {
+  const currentStage = props.studyData.metrics.eco.benefitCostRatio.stages.find(stage => stage.name === selectedStage.value);
   const currentStageActors = currentStage.actors;
   const tooltip = {}
   const items = currentStageActors.map((actor) => {

--- a/src/utils/data/metrics/eco/benefitCostRatio.js
+++ b/src/utils/data/metrics/eco/benefitCostRatio.js
@@ -1,18 +1,18 @@
 import _ from "lodash";
 
-export function buildReturnOnInvestmentData(ecoData) {
+export function buildBenefitCostRatioData(ecoData) {
   const stages = ecoData.stages;
   const actors = ecoData.actors;
 
-  const stagesData = stages.map(stage => buildStageReturnOnInvestmentData(stage, actors))
+  const stagesData = stages.map(stage => buildStageBenefitCostRatioData(stage, actors))
   return {
     benefitCostRatio: buildStudyBenefitCostRatio(stagesData),
     stages: stagesData
   }
 }
 
-function buildStageReturnOnInvestmentData(stage, actors) {
-  const stageActors = actors.filter((actor) => actor.stage === stage.name).map(buildActorReturnOnInvestmentData);
+function buildStageBenefitCostRatioData(stage, actors) {
+  const stageActors = actors.filter((actor) => actor.stage === stage.name).map(buildActorBenefitCostRatioData);
 
   const netOperatingProfits = _.sumBy(stageActors, "netOperatingProfits");
   const totalCosts = _.sumBy(stageActors, "totalCosts");
@@ -33,7 +33,7 @@ function buildStudyBenefitCostRatio(stagesData) {
   return netOperatingProfits / totalCosts;
 }
 
-function buildActorReturnOnInvestmentData(actor) {
+function buildActorBenefitCostRatioData(actor) {
   const netOperatingProfits = actor.netOperatingProfit || 0;
   let totalCosts = actor.totalCosts;
 

--- a/src/utils/data/metrics/eco/returnOnInvestment.js
+++ b/src/utils/data/metrics/eco/returnOnInvestment.js
@@ -37,7 +37,7 @@ function buildActorReturnOnInvestmentData(actor) {
   const netOperatingProfits = actor.netOperatingProfit || 0;
   let totalCosts = actor.totalCosts;
 
-  if (actor.stage === 'Producers') {
+  if (paysThemselvesWithProfits(actor)) {
     totalCosts += netOperatingProfits;
   }
   return {
@@ -47,4 +47,8 @@ function buildActorReturnOnInvestmentData(actor) {
     totalCosts,
     benefitCostRatio: netOperatingProfits / totalCosts,
   };
+}
+
+function paysThemselvesWithProfits(actor) {
+  return actor.stage === 'Producers';
 }

--- a/src/utils/data/metrics/index.js
+++ b/src/utils/data/metrics/index.js
@@ -1,4 +1,4 @@
-import { buildReturnOnInvestmentData } from "./eco/returnOnInvestment";
+import { buildBenefitCostRatioData } from "./eco/benefitCostRatio";
 
 export function computeMetrics(studyData) {
   return {
@@ -10,6 +10,6 @@ function buildEcoMetrics(studyData) {
   if (! studyData.ecoData) { return null; }
 
   return {
-    returnOnInvestment: buildReturnOnInvestmentData(studyData.ecoData)
+    benefitCostRatio: buildBenefitCostRatioData(studyData.ecoData)
   };
 }


### PR DESCRIPTION
Resolves #67

## Contexte

On veut afficher plus de données dans la page de comparaison grace a un menu déroulant

- Le ratio Benefice/couts (avec un dropdown par `stage`
- On veut également avoir des dropdown avec tous les sous-aspects sociaux

Screenshot (style non final)

[Screencast from 2024-08-21 15-40-03.webm](https://github.com/user-attachments/assets/bf54eb05-8a43-4eec-b40f-14a91f0ba251)

## Plan de PRs

- [85](https://github.com/leonarf/VCA4D/pull/85) Création d'un composant pour le dropdown
- À merger simulatanément
  - [88](https://github.com/leonarf/VCA4D/pull/88): Ajout des données
  - [89](https://github.com/leonarf/VCA4D/pull/89) Améliorer le style de ces dropdowns
- :dart: **Cette PR**: Quelques améliorations de style

## Commits

- Quelques améliorations de style
  - Update de la marge
  - Mise en gras au hover du parent-row
- Boyscout: Ajout d'une fonction pour clarifier l'ajout des profits aux couts pour les Producers

