### PR TITLE
fix: Display generic currency if it's the Local one

### DIFF
--- a/src/components/study/CurrencySelector.vue
+++ b/src/components/study/CurrencySelector.vue
@@ -11,12 +11,14 @@
       <option v-else value="LOCAL">
         {{ localCurrency }} ({{ getCurrencySymbol(localCurrency) }})
       </option>
-      <option v-if="localCurrency !== 'USD' && isCurrencySupported(localCurrency)" value="USD">
-        {{ getCurrencyName('USD') }} ({{ getCurrencySymbol('USD') }})
-      </option>
-      <option v-if="localCurrency !== 'EUR' && isCurrencySupported(localCurrency)" value="EUR">
-        {{ getCurrencyName('EUR') }} ({{ getCurrencySymbol('EUR') }})
-      </option>
+      <template v-if="isCurrencySupported(localCurrency)">
+        <option v-if="localCurrency !== 'USD'" value="USD">
+          {{ getCurrencyName('USD') }} ({{ getCurrencySymbol('USD') }})
+        </option>
+        <option v-if="localCurrency !== 'EUR'" value="EUR">
+          {{ getCurrencyName('EUR') }} ({{ getCurrencySymbol('EUR') }})
+        </option>
+      </template>
     </select>
   </div>
 </template>

--- a/src/components/study/CurrencySelector.vue
+++ b/src/components/study/CurrencySelector.vue
@@ -37,8 +37,12 @@ const props = defineProps({
 
 const selectedCurrency = ref(props.currency);
 watch(() => props.currency, () => {
-  selectedCurrency.value = props.currency;
-});
+  if (isGeneric(props.localCurrency) && props.currency === "LOCAL") {
+    selectedCurrency.value = props.localCurrency;
+  } else {
+    selectedCurrency.value = props.currency;
+  }
+}, { immediate: true });
 
 const emits = defineEmits(['update:currency'])
 

--- a/src/components/study/CurrencySelector.vue
+++ b/src/components/study/CurrencySelector.vue
@@ -5,17 +5,20 @@
       v-model="selectedCurrency"
       @change="emits('update:currency', $event.target.value)"
     >
-      <option v-if="isCurrencySupported(localCurrency)" value="LOCAL">
-        {{ getCurrencyName(localCurrency) }} ({{ getCurrencySymbol(localCurrency) }})
-      </option>
-      <option v-else value="LOCAL">
-        {{ localCurrency }} ({{ getCurrencySymbol(localCurrency) }})
-      </option>
+      <template v-if="! isGeneric(localCurrency)">
+        
+        <option v-if="isCurrencySupported(localCurrency)" value="LOCAL">
+          {{ getCurrencyName(localCurrency) }} ({{ getCurrencySymbol(localCurrency) }})
+        </option>
+        <option v-else value="LOCAL">
+          {{ localCurrency }} ({{ getCurrencySymbol(localCurrency) }})
+        </option>
+      </template>
       <template v-if="isCurrencySupported(localCurrency)">
-        <option v-if="localCurrency !== 'USD'" value="USD">
+        <option value="USD">
           {{ getCurrencyName('USD') }} ({{ getCurrencySymbol('USD') }})
         </option>
-        <option v-if="localCurrency !== 'EUR'" value="EUR">
+        <option value="EUR">
           {{ getCurrencyName('EUR') }} ({{ getCurrencySymbol('EUR') }})
         </option>
       </template>
@@ -38,6 +41,10 @@ watch(() => props.currency, () => {
 });
 
 const emits = defineEmits(['update:currency'])
+
+function isGeneric(currency) {
+  return ["USD", "EUR"].includes(currency);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -32,7 +32,7 @@
           <div class="subtitle">
             {{ currencySubtitle }}
             <InfoTooltip
-              v-if="currency !== 'LOCAL'"
+              v-if="! isLocalCurrencyDisplayed"
               text="Using the World Bank's currency rates for the reference year"
             />
           </div>
@@ -88,11 +88,14 @@ let dataToDisplay = computed(() => {
 })
 
 const currencySubtitle = computed(() => {
-  if (props.currency === "LOCAL") {
-     return "Local currency"
+  if (isLocalCurrencyDisplayed.value) {
+    return "Local currency";
   } else {
     return `Converted from ${getCurrencyName(props.localCurrency)}`;
   }
+})
+const isLocalCurrencyDisplayed = computed(() => {
+  return props.currency === "LOCAL" || props.currency === props.localCurrency;
 })
 </script>
 

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -61,7 +61,7 @@ const error = ref(undefined)
 
 function updateCurrency(newCurrency) {
     localStorage.setItem('currency', newCurrency);
-    router.push({ query: {
+    router.replace({ query: {
       ...route.query,
       currency: newCurrency
     } })


### PR DESCRIPTION
Resolves #86

## Contexte

Lorsqu'on a une étude qui a pour devise locale une des 2 génériques (USD/EUR), on ne voit pas la devise en allant sur l'url avec `currency=USD`
![image](https://github.com/user-attachments/assets/f37ff722-b7dc-4b4b-aa43-cb5c6d869dc2)

C'est parce que l'option `USD` n'existe pas dans ce cas la

## Commits

- Inversion des options possibles: Si la localCurrency est générique, on affiche seulement l'option générique
  - De cette manière, si l'user choisit cette option, on met la currency générique dans le localStorage, ce qui permet une meilleure comparaison avec les étude prochainement visitée
- [fix] Si l'url indique LOCAL, on caste l'affichage au générique (problème inverse du ticket, vu qu'on a inversé la logique ci dessus)
- Affichage de `Local currency` en sous-titre dans ce cas ou la locale === la générique
