### PR TITLE
feat: Better unit selection for Sankey

### DIFF
--- a/src/components/StudyOverview.vue
+++ b/src/components/StudyOverview.vue
@@ -68,6 +68,7 @@
     >
     <section v-if="studyData && studyData.ecoData">
       <Sankey :studyData="studyData" />
+      <AttachmentLink :studyId="studyData.id" attachmentType="eco.xlsx" />
     </section>
   </article>
 </template>
@@ -78,6 +79,7 @@ import StagesDescription from '@/components/StagesDescription.vue'
 import SectionTitle from './typography/SectionTitle.vue'
 import PdfSection from './pdf/PdfSection.vue';
 import Sankey from './charts/Sankey.vue'
+import AttachmentLink from '@components/pdf/AttachmentLink.vue'
 
 const props = defineProps({
   studyData: Object,

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -1,5 +1,5 @@
 <template>
-  <h3>{{ SANKEY_TITLE }}</h3>
+  <h3>The various actors and their share in the flows of the value chain</h3>
   <h4>Unit : {{ sankeyDisplayMode }} (logarithme scale)</h4>
   <SankeyChart :options="populatedSankeyChartData"></SankeyChart>
   <button
@@ -14,22 +14,13 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { getSankeyData } from '@/charts/sankey.js'
-import { getStudyFileAttachmentUrl } from '@/utils/data/pdf.js'
 import AttachmentLink from '@components/pdf/AttachmentLink.vue'
 
 import SankeyChart from '../SankeyChart.vue'
 
-const SANKEY_TITLE = 'The various actors and their share in the flows of the value chain'
-
 const props = defineProps({
   studyData: Object
 })
-
-let economicFileUrl = ref(null)
-console.log('props.studyData', props.studyData)
-getStudyFileAttachmentUrl(props.studyData.id, 'eco.xlsx').then(
-  (url) => (economicFileUrl.value = url)
-)
 
 const sankeyGraphPossibleDisplayModesList = ['monetaryValue', 'volumeExchanged']
 
@@ -40,9 +31,7 @@ const toggleSankeyGraphDisplayMode = () => {
     (sankeyGraphDisplayModeIndex.value + 1) % sankeyGraphPossibleDisplayModesList.length
 }
 
-const sankeyDisplayMode = computed(
-  () => sankeyGraphPossibleDisplayModesList[sankeyGraphDisplayModeIndex.value]
-)
+const sankeyDisplayMode = computed(() => sankeyGraphPossibleDisplayModesList[sankeyGraphDisplayModeIndex.value])
 
 const populatedSankeyChartData = computed(() =>
   getSankeyData(props.studyData, sankeyDisplayMode.value)

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -1,5 +1,5 @@
 <template>
-  <h3>The various actors and their share in the flows of the value chain</h3>
+  <h2>The various actors and their share in the flows of the value chain</h2>
   <RadioInput
     title="Unit selection"
     :options="sankeyGraphPossibleDisplayModesList"

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -7,14 +7,12 @@
     @update:selected="$event => sankeyDisplayMode = $event"
   />
   <SankeyChart :options="populatedSankeyChartData"></SankeyChart>
-  <AttachmentLink :studyId="studyData.id" attachmentType="eco.xlsx" />
 </template>
 
 <script setup>
 import { computed, ref } from 'vue'
 import RadioInput from '@components/study/RadioInput.vue';
 import { getSankeyData } from '@/charts/sankey.js';
-import AttachmentLink from '@components/pdf/AttachmentLink.vue'
 
 import SankeyChart from '../SankeyChart.vue'
 

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -1,19 +1,19 @@
 <template>
   <h3>The various actors and their share in the flows of the value chain</h3>
-  <h4>Unit : {{ sankeyDisplayMode }} (logarithme scale)</h4>
+  <RadioInput
+    title="Unit selection"
+    :options="sankeyGraphPossibleDisplayModesList"
+    :selected="sankeyDisplayMode"
+    @update:selected="$event => sankeyDisplayMode = $event"
+  />
   <SankeyChart :options="populatedSankeyChartData"></SankeyChart>
-  <button
-    className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-    @click="toggleSankeyGraphDisplayMode"
-  >
-    Switch unit
-  </button>
   <AttachmentLink :studyId="studyData.id" attachmentType="eco.xlsx" />
 </template>
 
 <script setup>
 import { computed, ref } from 'vue'
-import { getSankeyData } from '@/charts/sankey.js'
+import RadioInput from '@components/study/RadioInput.vue';
+import { getSankeyData } from '@/charts/sankey.js';
 import AttachmentLink from '@components/pdf/AttachmentLink.vue'
 
 import SankeyChart from '../SankeyChart.vue'
@@ -22,16 +22,11 @@ const props = defineProps({
   studyData: Object
 })
 
-const sankeyGraphPossibleDisplayModesList = ['monetaryValue', 'volumeExchanged']
-
-const sankeyGraphDisplayModeIndex = ref(0)
-
-const toggleSankeyGraphDisplayMode = () => {
-  sankeyGraphDisplayModeIndex.value =
-    (sankeyGraphDisplayModeIndex.value + 1) % sankeyGraphPossibleDisplayModesList.length
-}
-
-const sankeyDisplayMode = computed(() => sankeyGraphPossibleDisplayModesList[sankeyGraphDisplayModeIndex.value])
+const sankeyGraphPossibleDisplayModesList = [
+  { label: "Volumes exchanged", value: "volumeExchanged", subtitle: "From left to right, the flow of goods in the value chain in kilograms" },
+  { label: "Monetary flow", value: "monetaryValue", subtitle: "From right to left, the transfer of value from consumers to producers" },
+]
+const sankeyDisplayMode = ref(sankeyGraphPossibleDisplayModesList[0].value);
 
 const populatedSankeyChartData = computed(() =>
   getSankeyData(props.studyData, sankeyDisplayMode.value)


### PR DESCRIPTION
Issue: #68 

## Contexte

On refacto la style pour la section Sakey de l'overview, notamment la selection d'unité

| Avant | Après |
| - | - |
| ![image](https://github.com/user-attachments/assets/71c13b35-a734-44d5-90d0-9f313705d723) | ![image](https://github.com/user-attachments/assets/4eea182d-c259-4353-bfa5-b55e42c6bd5c) |

## Commits

- Un peu de cleanup
- Utilisation de RadioInput
- Titre en `h2` comme précisé [ici](https://github.com/leonarf/VCA4D/issues/82#issuecomment-2304316570)