### PR TITLE
feat(68): Compute sankey depth by links number from source

### DIFF
--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { useCurrencyUtils } from '@utils/format.js'
 import { getColor } from '@utils/colors.js'
+import { buildDepthByActor } from "./sankeyDepth";
 
 const getNodeGap = (studyData) => {
     // First we look at number of flows we have. We force it in the range [10, 40]
@@ -36,77 +37,8 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
             nodeGap: getNodeGap(studyData)
         }
     };
-
-    // For each flow we identify the source Stage and the destination Stage
-    const sankeyFlows = flows.map(flow => {
-        const sourceActor = actors.find(a => a.name === flow.sellerActorName)
-        var sourceStage = "Unknown"
-        if (!sourceActor) {
-            console.log(`did not found actor ${flow.sellerActorName} in actors`)
-        } else {
-            sourceStage = sourceActor.stage
-        }
-        const destActor = actors.find(a => a.name === flow.buyerActorName)
-        var destStage = "Unknown"
-        if (!destActor) {
-            console.log(`did not found actor ${flow.buyerActorName} in actors`)
-        } else {
-            destStage = destActor.stage
-        }
-
-        return {
-            ...flow,
-            sourceStage,
-            destStage
-        }
-    })
-
-    // List of all stages in flows
-    let sankeyStages = [...new Set(sankeyFlows.map(sFlow => [sFlow.sourceStage, sFlow.destStage])
-        .reduce((arr, val) => arr.concat(val), []))]
-
-    // For each stage, identify the list of source stages and destination stages.
-    sankeyStages = sankeyStages.map(stage => {
-        const flowsToStage = sankeyFlows.filter(sFlow => sFlow.destStage === stage && sFlow.sourceStage !== stage).map(sFlow => sFlow.sourceStage)
-        const flowsFromStage = sankeyFlows.filter(sFlow => sFlow.sourceStage === stage && sFlow.destStage !== stage).map(sFlow => sFlow.destStage)
-
-        let ret = {
-            name: stage,
-            inStages: [...new Set(flowsToStage)],
-            outStages: [...new Set(flowsFromStage)],
-        }
-        // Stages that have no sources have an index of 0. Flows only start from them
-        if (flowsToStage.length === 0) {
-            ret = {
-                ...ret,
-                index: 0
-            }
-        }
-        return ret
-    })
-
-    // Attribute an index to each stage. If a stage with index N give a flow to another stage it will have index N + 1
-    for (let idx = 0; idx < 15; idx++) {
-        const stages = sankeyStages.filter(sStage => sStage.index === idx)
-        const outStages = [... new Set(stages.reduce((arr, stage) => arr.concat(stage.outStages), []))]
-        if (outStages.length === 0) {
-            break
-        }
-        for (const toStage of outStages) {
-            let tmpStage = sankeyStages.find(stage => stage.name === toStage)
-            if (!tmpStage.index) {
-                tmpStage.index = idx + 1
-            }
-        }
-    }
-
-    const depthByActor = {};
-    const maxDepth = Math.max(...sankeyStages.map(sStage => sStage.index))
-    actors.forEach((actor) => {
-      const sankeyStage = sankeyStages.find(sStage => sStage.name === actor.stage)
-      depthByActor[actor.id] = sankeyStage ? sankeyStage.index : maxDepth + 1; // Actor with unknown stages will be at far right,
-    });
-
+    const depthByActor = buildDepthByActor(actors, flows);
+    
     result.series.levels = _.orderBy(_.uniq(Object.values(depthByActor)))
       .map((_depth, index) => ({
         depth: index,

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -84,7 +84,6 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
         return ret
     })
 
-    sankeyStages.forEach(item => {item.color = getColor(item.name)})
     // Attribute an index to each stage. If a stage with index N give a flow to another stage it will have index N + 1
     for (let idx = 0; idx < 15; idx++) {
         const stages = sankeyStages.filter(sStage => sStage.index === idx)
@@ -108,19 +107,21 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
         }
     }))
 
+    const depthByActor = {};
     const maxDepth = Math.max(...sankeyStages.map(sStage => sStage.index))
-    result.series.maxDepth = maxDepth + 1
+    actors.forEach((actor) => {
+      const sankeyStage = sankeyStages.find(sStage => sStage.name === actor.stage)
+      depthByActor[actor.id] = sankeyStage ? sankeyStage.index : maxDepth + 1; // Actor with unknown stages will be at far right,
+    });
+
+    result.series.maxDepth = Math.max(...Object.values(depthByActor));
     // It looks like in echarts, "nodes" key can also be named "data"
     result.series.nodes = actors.map((actor) => {
-        const sankeyStage = sankeyStages.find(sStage => sStage.name === actor.stage)
-        if (!sankeyStage) {
-            console.log("Stage not found for", actor)
-        }
         return {
             "name": actor.name,
-            "depth": sankeyStage ? sankeyStage.index : maxDepth + 1, // Actor with unknown stages will be at far right,
+            "depth": depthByActor[actor.id],
             itemStyle: {
-                color: sankeyStage.color
+                color: getColor(actor.stage)
             }
         };
     });

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { useCurrencyUtils } from '@utils/format.js'
 import { getColor } from '@utils/colors.js'
 
@@ -99,14 +100,6 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
         }
     }
 
-    result.series.levels = sankeyStages.map(sStage => ({
-        depth: sStage.index,
-        lineStyle: {
-            color: 'source',
-            opacity: 0.4
-        }
-    }))
-
     const depthByActor = {};
     const maxDepth = Math.max(...sankeyStages.map(sStage => sStage.index))
     actors.forEach((actor) => {
@@ -114,6 +107,14 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
       depthByActor[actor.id] = sankeyStage ? sankeyStage.index : maxDepth + 1; // Actor with unknown stages will be at far right,
     });
 
+    result.series.levels = _.orderBy(_.uniq(Object.values(depthByActor)))
+      .map((_depth, index) => ({
+        depth: index,
+        lineStyle: {
+            color: 'source',
+            opacity: 0.4
+        }
+    }))
     result.series.maxDepth = Math.max(...Object.values(depthByActor));
     // It looks like in echarts, "nodes" key can also be named "data"
     result.series.nodes = actors.map((actor) => {

--- a/src/charts/sankeyDepth.js
+++ b/src/charts/sankeyDepth.js
@@ -1,0 +1,73 @@
+export function buildDepthByActor(actors, flows) {
+    // For each flow we identify the source Stage and the destination Stage
+    const sankeyFlows = flows.map(flow => {
+      const sourceActor = actors.find(a => a.name === flow.sellerActorName)
+      var sourceStage = "Unknown"
+      if (!sourceActor) {
+          console.log(`did not found actor ${flow.sellerActorName} in actors`)
+      } else {
+          sourceStage = sourceActor.stage
+      }
+      const destActor = actors.find(a => a.name === flow.buyerActorName)
+      var destStage = "Unknown"
+      if (!destActor) {
+          console.log(`did not found actor ${flow.buyerActorName} in actors`)
+      } else {
+          destStage = destActor.stage
+      }
+
+      return {
+          ...flow,
+          sourceStage,
+          destStage
+      }
+  })
+
+  // List of all stages in flows
+  let sankeyStages = [...new Set(sankeyFlows.map(sFlow => [sFlow.sourceStage, sFlow.destStage])
+      .reduce((arr, val) => arr.concat(val), []))]
+
+  // For each stage, identify the list of source stages and destination stages.
+  sankeyStages = sankeyStages.map(stage => {
+      const flowsToStage = sankeyFlows.filter(sFlow => sFlow.destStage === stage && sFlow.sourceStage !== stage).map(sFlow => sFlow.sourceStage)
+      const flowsFromStage = sankeyFlows.filter(sFlow => sFlow.sourceStage === stage && sFlow.destStage !== stage).map(sFlow => sFlow.destStage)
+
+      let ret = {
+          name: stage,
+          inStages: [...new Set(flowsToStage)],
+          outStages: [...new Set(flowsFromStage)],
+      }
+      // Stages that have no sources have an index of 0. Flows only start from them
+      if (flowsToStage.length === 0) {
+          ret = {
+              ...ret,
+              index: 0
+          }
+      }
+      return ret
+  })
+
+  // Attribute an index to each stage. If a stage with index N give a flow to another stage it will have index N + 1
+  for (let idx = 0; idx < 15; idx++) {
+      const stages = sankeyStages.filter(sStage => sStage.index === idx)
+      const outStages = [... new Set(stages.reduce((arr, stage) => arr.concat(stage.outStages), []))]
+      if (outStages.length === 0) {
+          break
+      }
+      for (const toStage of outStages) {
+          let tmpStage = sankeyStages.find(stage => stage.name === toStage)
+          if (!tmpStage.index) {
+              tmpStage.index = idx + 1
+          }
+      }
+  }
+
+  const depthByActor = {};
+  const maxDepth = Math.max(...sankeyStages.map(sStage => sStage.index))
+  actors.forEach((actor) => {
+    const sankeyStage = sankeyStages.find(sStage => sStage.name === actor.stage)
+    depthByActor[actor.id] = sankeyStage ? sankeyStage.index : maxDepth + 1; // Actor with unknown stages will be at far right,
+  });
+
+  return depthByActor;
+}

--- a/src/charts/sankeyDepth.js
+++ b/src/charts/sankeyDepth.js
@@ -2,14 +2,11 @@ import _ from "lodash";
 
 export function buildDepthByActor(actors, flows) {
   const { edges, nodes } = buildNodesAndEdges(actors, flows);
-  const {
-    childNodesByNode,
-    sourceNodes
-   } = parseGraph(nodes, edges);
+  const { childNodesByNode } = parseGraph(edges);
 
+  const sourceNodes = getProducersNodes(actors);
   const depthByNode = buildDepthForLinkedNodes(sourceNodes, { childNodesByNode });
   assignMaximumDepthToRemainingNodes(depthByNode, nodes);
-
   return depthByNode;
 }
 
@@ -50,18 +47,13 @@ function buildNodesAndEdges(actors, flows) {
   return { nodes, edges };
 }
 
-function parseGraph(nodes, edges) {
+function parseGraph(edges) {
   const childNodesByNode = {};
-  const parentNodesByNode = {};
   edges.forEach(([sourceNode, targetNode]) => {
     addToNodesDictionary(childNodesByNode, { key: sourceNode, value: targetNode });
-    addToNodesDictionary(parentNodesByNode, { key: targetNode, value: sourceNode });
   });
 
-  return {
-    childNodesByNode,
-    sourceNodes: getNodesWithoutParents(nodes, parentNodesByNode)
-  };
+  return { childNodesByNode };
 
   function addToNodesDictionary(dictionary, { key, value }) {
     if (! dictionary[key]) { dictionary[key] = []; }
@@ -69,7 +61,7 @@ function parseGraph(nodes, edges) {
     dictionary[key] = _.uniq([...dictionary[key], value]) // In case there's several flows from and to the same nodes
   }
 }
-function getNodesWithoutParents(nodes, parentNodesByNode) {
-  const nodesWithParents = Object.keys(parentNodesByNode).map(key => parseInt(key, 10));
-  return _.difference(nodes, nodesWithParents);
+
+function getProducersNodes(actors) {
+  return actors.filter(actor => actor.stage === "Producers").map(actor => actor.id);
 }

--- a/src/charts/sankeyDepth.js
+++ b/src/charts/sankeyDepth.js
@@ -15,17 +15,19 @@ export function buildDepthByActor(actors, flows) {
 
 function buildDepthForLinkedNodes(sourceNodes, { childNodesByNode, parentNodesByNode }) {
   const depthByNode = {};
-  sourceNodes.forEach(sourceNode => markNodeDepthAsMinimum(sourceNode, 0));
+  sourceNodes.forEach(sourceNode => markNodeDepthAsMinimum(sourceNode, 0, []));
   return depthByNode;
 
-  function markNodeDepthAsMinimum(node, minimumDepth) {
+  function markNodeDepthAsMinimum(node, minimumDepth, ancestryNodes) {
+    if (ancestryNodes.includes(node)) { return; } // Stop the loop
+
     if (_.isUndefined(depthByNode[node])) {
       depthByNode[node] = 0; 
     }
     depthByNode[node] = Math.max(depthByNode[node], minimumDepth);
 
     if (! childNodesByNode[node]) { return; }
-    childNodesByNode[node].forEach(childNode => markNodeDepthAsMinimum(childNode, minimumDepth + 1));
+    childNodesByNode[node].forEach(childNode => markNodeDepthAsMinimum(childNode, minimumDepth + 1, [...ancestryNodes, node]));
   }
 }
 


### PR DESCRIPTION
## Contexte

On veut retravailler l'affichage du sankey

La version précédente calculait la profondeur des éléments en les associant à un stage précis. Le problème est que certains stages se lient entre eux, rendant le sankey difficilement lisible.

Dans cette PR, je recalcule la profondeur en fonction du nombre de liens depuis la source

Note: C'est certainement ce que fait déjà echarts par défaut (si on ne passe pas de `depth`, le graphe est similaire). Mais cette PR est une première étape pour mieux afficher la profondeur. J'essayerais ensuite de grouper les noeuds par stage.

## Commits

- Extraction de la logique de profondeur
- Reecriture de cette logique