### PR TITLE
feat(68): Improve Sankey format (+ color refactor)

### DIFF
--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -89,7 +89,7 @@ export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurren
                   "Remark": params.data['Remark'],
                 });
               default:
-                return "";
+                console.error("Unrecognized dataType");
             }
         }
     };

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -3,9 +3,9 @@ import { useCurrencyUtils } from '@utils/format.js'
 import { getColor } from '@utils/colors.js'
 import { buildDepthByActor } from "./sankeyDepth";
 
-const getNodeGap = (studyData) => {
+const getNodeGap = (flows) => {
     // First we look at number of flows we have. We force it in the range [10, 40]
-    const nbFlows  = studyData.ecoData.flows.length
+    const nbFlows  = flows.length
     const MIN_NB_FLOWS = 10
     const MAX_NB_FLOWS = 40
     const normalizedNbFlows = Math.max(Math.min(nbFlows, MAX_NB_FLOWS), MIN_NB_FLOWS)
@@ -18,10 +18,9 @@ const getNodeGap = (studyData) => {
     return Math.floor(MIN_NODE_GAP + (1.0 - percent) * (MAX_NODE_GAP - MIN_NODE_GAP))
 }
 
-export const getSankeyData = (studyData, sankeyDisplayMode) => {
-    const { prettyAmount, convertAmount } = useCurrencyUtils({currency : studyData.targetCurrency});
-    let monetaryCurrency = studyData.targetCurrency
-    const { actors, flows } = studyData.ecoData
+export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurrency }) => {
+    const { prettyAmount, convertAmount } = useCurrencyUtils({currency: monetaryCurrency});
+    
 
     let result = {
         title: {
@@ -34,7 +33,7 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
                 focus: 'adjacency'
             },
             nodeWidth: 20,
-            nodeGap: getNodeGap(studyData)
+            nodeGap: getNodeGap(flows)
         }
     };
     const depthByActor = buildDepthByActor(actors, flows);

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -1,6 +1,5 @@
 import _ from "lodash";
 import { useCurrencyUtils } from '@utils/format.js'
-import { getColor } from '@utils/colors.js'
 import { buildDepthByActor } from "./sankeyDepth";
 
 const getNodeGap = (flows) => {
@@ -19,7 +18,7 @@ const getNodeGap = (flows) => {
 }
 
 export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurrency }) => {
-    const { prettyAmount, convertAmount } = useCurrencyUtils({currency: monetaryCurrency});
+    const { prettyAmount } = useCurrencyUtils({currency: monetaryCurrency});
     
 
     let result = {
@@ -53,7 +52,7 @@ export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurren
             "name": actor.name,
             "depth": depthByActor[actor.id],
             itemStyle: {
-                color: getColor(actor.stage)
+                color: actor.color
             }
         };
     });

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -88,30 +88,26 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
         trigger: 'item',
         triggerOn: 'mousemove',
         formatter: (params) => {
-            if (params?.dataType === "node" || params?.dataType === "edge"){
-                if (params?.dataType === "node"){
-                    const actorStage = actors.find((actor) => actor.name === params.data.name);
-                    const actorStageLabel = actorStage ? actorStage.stage : undefined;
-                    return formatTooltip({
-                      "Name": params.data.name,
-                      "Stage": actorStageLabel
-                    });
-                }
-                else if (params?.dataType === "edge"){
-                  return formatTooltip({
-                    "Source": params.data.source,
-                    "Target": params.data.target,
-                    "Monetary value": prettyAmount.value(params.data["Monetary value"], monetaryCurrency),
-                    "Products": params.data['Products'],
-                    "Unitary price (local curency)": prettyAmount.value(params.data['Unitary price (local curency)'], monetaryCurrency),
-                    "Volume exchanged (kg Of product)": params.data['Volume exchanged (kg Of product)'],
-                    "Volume unit": params.data['Volume unit'],
-                    "Remark": params.data['Remark'],
-                  });
-                }
-            }
-            else {
-                return '';
+            switch (params?.dataType) {
+              case "node":
+                const actor = actors.find((actor) => actor.name === params.data.name);
+                return formatTooltip({
+                  "Name": params.data.name,
+                  "Stage": actor ? actor.stage : undefined
+                });
+              case "edge":
+                return formatTooltip({
+                  "Source": params.data.source,
+                  "Target": params.data.target,
+                  "Monetary value": prettyAmount.value(params.data["Monetary value"], monetaryCurrency),
+                  "Products": params.data['Products'],
+                  "Unitary price (local curency)": prettyAmount.value(params.data['Unitary price (local curency)'], monetaryCurrency),
+                  "Volume exchanged (kg Of product)": params.data['Volume exchanged (kg Of product)'],
+                  "Volume unit": params.data['Volume unit'],
+                  "Remark": params.data['Remark'],
+                });
+              default:
+                return "";
             }
         }
     };

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -2,21 +2,6 @@ import _ from "lodash";
 import { useCurrencyUtils } from '@utils/format.js'
 import { buildDepthByActor } from "./sankeyDepth";
 
-const getNodeGap = (flows) => {
-    // First we look at number of flows we have. We force it in the range [10, 40]
-    const nbFlows  = flows.length
-    const MIN_NB_FLOWS = 10
-    const MAX_NB_FLOWS = 40
-    const normalizedNbFlows = Math.max(Math.min(nbFlows, MAX_NB_FLOWS), MIN_NB_FLOWS)
-
-    // Based on the number of flows, we set a "Node gap".
-    // Node gap will be between 50 and 200. The more flows, the smallest node gap
-    const percent = (normalizedNbFlows - MIN_NB_FLOWS) / (MAX_NB_FLOWS - MIN_NB_FLOWS)
-    const MIN_NODE_GAP = 50
-    const MAX_NODE_GAP = 200
-    return Math.floor(MIN_NODE_GAP + (1.0 - percent) * (MAX_NODE_GAP - MIN_NODE_GAP))
-}
-
 export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurrency }) => {
     const { prettyAmount } = useCurrencyUtils({currency: monetaryCurrency});
     
@@ -31,8 +16,7 @@ export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurren
             emphasis: {
                 focus: 'adjacency'
             },
-            nodeWidth: 20,
-            nodeGap: getNodeGap(flows)
+            nodeWidth: 20
         }
     };
     const depthByActor = buildDepthByActor(actors, flows);

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -87,67 +87,28 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
     result.tooltip = {
         trigger: 'item',
         triggerOn: 'mousemove',
-        formatter: (params, ticket) => {
+        formatter: (params) => {
             if (params?.dataType === "node" || params?.dataType === "edge"){
-                let items = [];
-                let rendered_items = [];
                 if (params?.dataType === "node"){
                     const actorStage = actors.find((actor) => actor.name === params.data.name);
                     const actorStageLabel = actorStage ? actorStage.stage : undefined;
-                    items = [
-                        {
-                            label: "Name",
-                            value: params.data.name
-                        },
-                        {
-                            label: "Stage",
-                            value: actorStageLabel
-                        }
-                    ];
+                    return formatTooltip({
+                      "Name": params.data.name,
+                      "Stage": actorStageLabel
+                    });
                 }
                 else if (params?.dataType === "edge"){
-                    items = [
-                        {
-                            label: "Source",
-                            value: params.data.source,
-                        },
-                        {
-                            label: "Target",
-                            value: params.data.target
-                        },
-                        {
-                            label: "Monetary value",
-                            value: prettyAmount.value(params.data["Monetary value"], monetaryCurrency)
-                        },
-                        {
-                            label: "Products",
-                            value: params.data['Products']
-                        },
-                        {
-                            label: "Unitary price (local curency)",
-                            value: prettyAmount.value(params.data['Unitary price (local curency)'], monetaryCurrency)
-                        },
-                        {
-                            label: "Volume exchanged (kg Of product)",
-                            value: params.data['Volume exchanged (kg Of product)']
-                        },
-                        {
-                            label: "Volume unit",
-                            value: params.data['Volume unit']
-                        },
-                        {
-                            label: "Remark",
-                            value: params.data['Remark']
-                        }
-                    ];
+                  return formatTooltip({
+                    "Source": params.data.source,
+                    "Target": params.data.target,
+                    "Monetary value": prettyAmount.value(params.data["Monetary value"], monetaryCurrency),
+                    "Products": params.data['Products'],
+                    "Unitary price (local curency)": prettyAmount.value(params.data['Unitary price (local curency)'], monetaryCurrency),
+                    "Volume exchanged (kg Of product)": params.data['Volume exchanged (kg Of product)'],
+                    "Volume unit": params.data['Volume unit'],
+                    "Remark": params.data['Remark'],
+                  });
                 }
-                rendered_items = items.map((item) => {
-                    if (item.value === undefined){
-                        return null;
-                    }
-                    return `<li><strong>${item.label}</strong>: ${item.value}</li>`;
-                });
-                return `<div style='max-width: 400px; white-space: normal;'><ul style='list-style: initial; margin: 0 10px; padding: initial;'>${rendered_items.join('')}</ul></div>`;
             }
             else {
                 return '';
@@ -156,4 +117,22 @@ export const getSankeyData = (studyData, sankeyDisplayMode) => {
     };
     console.log("sankey chart options:", result)
     return result;
+}
+
+function formatTooltip(items) {
+  const tooltipItems = Object.entries(items)
+    .map(([itemLabel, itemValue]) => formatTooltipItem(itemLabel, itemValue));
+
+  return `
+    <div style='max-width: 400px; white-space: normal;'>
+      <ul style='list-style: initial; margin: 0 10px; padding: initial;'>
+        ${tooltipItems.join('')}
+      </ul>
+    </div>
+  `;
+}
+function formatTooltipItem(label, value) {
+  return `
+    <li><strong>${label}</strong>: ${value}</li>
+  `;
 }

--- a/src/charts/sankeyDepth.js
+++ b/src/charts/sankeyDepth.js
@@ -7,9 +7,10 @@ import _ from "lodash";
 
 export function buildDepthByActor(actors, flows) {
   const { edges, nodes } = buildNodesAndEdges(actors, flows);
+  console.log(edges, nodes);
   const { childNodesByNode } = parseGraph(edges);
 
-  const sourceNodes = getProducersNodes(actors);
+  const sourceNodes = getSourceNodes(actors);
   const depthByNode = buildDepthForLinkedNodes(sourceNodes, { childNodesByNode });
   assignMaximumDepthToRemainingNodes(depthByNode, nodes);
   return depthByNode;
@@ -67,6 +68,10 @@ function parseGraph(edges) {
   }
 }
 
-function getProducersNodes(actors) {
-  return actors.filter(actor => actor.stage === "Producers").map(actor => actor.id);
+function getSourceNodes(actors) {
+  const producers = actors.filter(actor => actor.stage === "Producers");
+  
+  const sourceActors = producers.length ? producers : actors;
+
+  return sourceActors.map(actor => actor.id);
 }

--- a/src/charts/sankeyDepth.js
+++ b/src/charts/sankeyDepth.js
@@ -1,5 +1,10 @@
 import _ from "lodash";
 
+// This is similar to what echarts does if we don't provide `depth`.
+// However there's a few tweaks that help our case here
+// - This allows us to define `series.maxDepth` to better scale the sankey, sicne we know the maximum depth
+// - This allows us to force Producers to be on the left (if there's any loop, echarts might decide otherwise)
+
 export function buildDepthByActor(actors, flows) {
   const { edges, nodes } = buildNodesAndEdges(actors, flows);
   const { childNodesByNode } = parseGraph(edges);
@@ -10,7 +15,7 @@ export function buildDepthByActor(actors, flows) {
   return depthByNode;
 }
 
-function buildDepthForLinkedNodes(sourceNodes, { childNodesByNode, parentNodesByNode }) {
+function buildDepthForLinkedNodes(sourceNodes, { childNodesByNode }) {
   const depthByNode = {};
   sourceNodes.forEach(sourceNode => markNodeDepthAsMinimum(sourceNode, 0, []));
   return depthByNode;

--- a/src/charts/sankeyDepth.js
+++ b/src/charts/sankeyDepth.js
@@ -2,12 +2,11 @@ import _ from "lodash";
 
 // This is similar to what echarts does if we don't provide `depth`.
 // However there's a few tweaks that help our case here
-// - This allows us to define `series.maxDepth` to better scale the sankey, sicne we know the maximum depth
+// - This allows us to define `series.maxDepth` to better scale the sankey, since we know the maximum depth
 // - This allows us to force Producers to be on the left (if there's any loop, echarts might decide otherwise)
 
 export function buildDepthByActor(actors, flows) {
   const { edges, nodes } = buildNodesAndEdges(actors, flows);
-  console.log(edges, nodes);
   const { childNodesByNode } = parseGraph(edges);
 
   const sourceNodes = getSourceNodes(actors);

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -26,7 +26,7 @@ import RadioInput from '@components/study/RadioInput.vue';
 import { getSankeyData } from '@/charts/sankey.js';
 
 import SankeyChart from '../SankeyChart.vue'
-import { getColor } from '@utils/colors.js'
+import { getFixedColor } from '@utils/colors.js'
 
 const props = defineProps({
   studyData: Object
@@ -51,7 +51,7 @@ const populatedSankeyChartData = computed(() => {
 const populatedActors = computed(() => {
   return props.studyData.ecoData.actors.map(actor => ({
     ...actor,
-    color: getColor(actor.stage)
+    color: getSankeyColor(actor.stage)
   }));
 });
 
@@ -60,7 +60,7 @@ const legendItems = computed(() => {
   
   const stagesByColor = {};
   stages.forEach(stage => {
-    const color = getColor(stage);
+    const color = getSankeyColor(stage);
     if (! stagesByColor[color]) {
       stagesByColor[color] = [];
     }
@@ -69,6 +69,10 @@ const legendItems = computed(() => {
   })
   return Object.entries(stagesByColor).map(([color, stages]) => ({ color, stages }));
 });
+
+function getSankeyColor(stage) {
+  return getFixedColor(stage) || "#CACBCE";
+}
 </script>
 
 <style scoped lang="scss">

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -27,6 +27,7 @@ import { getSankeyData } from '@/charts/sankey.js';
 
 import SankeyChart from '../SankeyChart.vue'
 import { getFixedColor } from '@utils/colors.js'
+import { STAGES } from '@utils/stages'
 
 const props = defineProps({
   studyData: Object
@@ -56,7 +57,8 @@ const populatedActors = computed(() => {
 });
 
 const legendItems = computed(() => {
-  const stages = _.uniq(populatedActors.value.map(actor => actor.stage));
+  const stages = _.uniq(populatedActors.value.map(actor => actor.stage))
+    .sort(sortOnEarlierStage)
   
   const stagesByColor = {};
   stages.forEach(stage => {
@@ -69,6 +71,17 @@ const legendItems = computed(() => {
   })
   return Object.entries(stagesByColor).map(([color, stages]) => ({ color, stages }));
 });
+
+function sortOnEarlierStage(stage1, stage2) {
+  return getStageOrder(stage1) - getStageOrder(stage2);
+
+  function getStageOrder(stage) {
+    const index = STAGES.indexOf(stage);
+    if (index === -1) { return STAGES.length; }
+
+    return index;
+  }
+}
 
 function getSankeyColor(stage) {
   return getFixedColor(stage) || "#CACBCE";

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -15,6 +15,7 @@ import RadioInput from '@components/study/RadioInput.vue';
 import { getSankeyData } from '@/charts/sankey.js';
 
 import SankeyChart from '../SankeyChart.vue'
+import { getColor } from '@utils/colors.js'
 
 const props = defineProps({
   studyData: Object
@@ -27,11 +28,20 @@ const sankeyGraphPossibleDisplayModesList = [
 const sankeyDisplayMode = ref(sankeyGraphPossibleDisplayModesList[0].value);
 
 const populatedSankeyChartData = computed(() => {
-  const { actors, flows } = props.studyData.ecoData;
-  return getSankeyData(actors, flows, {
-    sankeyDisplayMode: sankeyDisplayMode.value,
-    monetaryCurrency: props.studyData.targetCurrency,
+  return getSankeyData(
+    populatedActors.value,
+    props.studyData.ecoData.flows,
+    {
+      sankeyDisplayMode: sankeyDisplayMode.value,
+      monetaryCurrency: props.studyData.targetCurrency,
   })
+})
+
+const populatedActors = computed(() => {
+  return props.studyData.ecoData.actors.map(actor => ({
+    ...actor,
+    color: getColor(actor.stage)
+  }));
 })
 </script>
 

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -26,7 +26,7 @@ import RadioInput from '@components/study/RadioInput.vue';
 import { getSankeyData } from '@/charts/sankey.js';
 
 import SankeyChart from '../SankeyChart.vue'
-import { getFixedColor } from '@utils/colors.js'
+import { getColor } from '@utils/colors.js'
 import { STAGES } from '@utils/stages'
 
 const props = defineProps({
@@ -52,7 +52,7 @@ const populatedSankeyChartData = computed(() => {
 const populatedActors = computed(() => {
   return props.studyData.ecoData.actors.map(actor => ({
     ...actor,
-    color: getSankeyColor(actor.stage)
+    color: getColor(actor.stage)
   }));
 });
 
@@ -62,7 +62,7 @@ const legendItems = computed(() => {
   
   const stagesByColor = {};
   stages.forEach(stage => {
-    const color = getSankeyColor(stage);
+    const color = getColor(stage);
     if (! stagesByColor[color]) {
       stagesByColor[color] = [];
     }
@@ -83,9 +83,6 @@ function sortOnEarlierStage(stage1, stage2) {
   }
 }
 
-function getSankeyColor(stage) {
-  return getFixedColor(stage) || "#CACBCE";
-}
 </script>
 
 <style scoped lang="scss">

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -6,10 +6,21 @@
     :selected="sankeyDisplayMode"
     @update:selected="$event => sankeyDisplayMode = $event"
   />
+  <div class="legend">
+    <div
+      v-for="(legendItem, index) in legendItems"
+      :key="index"
+      class="legend-item"
+    >
+      <div class="legend-color" :style="{ 'background-color': legendItem.color }"></div>
+      {{ legendItem.stages.join(", ") }}
+    </div>
+  </div>
   <SankeyChart :options="populatedSankeyChartData"></SankeyChart>
 </template>
 
 <script setup>
+import _ from "lodash"
 import { computed, ref } from 'vue'
 import RadioInput from '@components/study/RadioInput.vue';
 import { getSankeyData } from '@/charts/sankey.js';
@@ -42,8 +53,42 @@ const populatedActors = computed(() => {
     ...actor,
     color: getColor(actor.stage)
   }));
-})
+});
+
+const legendItems = computed(() => {
+  const stages = _.uniq(populatedActors.value.map(actor => actor.stage));
+  
+  const stagesByColor = {};
+  stages.forEach(stage => {
+    const color = getColor(stage);
+    if (! stagesByColor[color]) {
+      stagesByColor[color] = [];
+    }
+
+    stagesByColor[color].push(stage);
+  })
+  return Object.entries(stagesByColor).map(([color, stages]) => ({ color, stages }));
+});
 </script>
 
 <style scoped lang="scss">
+.legend {
+  margin-top: 30px;
+  display: flex;
+  gap: 24px;
+
+  .legend-item {
+    display: flex;
+    gap: 10px;
+    align-items: baseline;
+
+    .legend-color {
+      height: 12px;
+      width: 12px;
+      position: relative;
+
+      flex-shrink: 0;
+    }
+  }
+}
 </style>

--- a/src/components/charts/Sankey.vue
+++ b/src/components/charts/Sankey.vue
@@ -26,9 +26,13 @@ const sankeyGraphPossibleDisplayModesList = [
 ]
 const sankeyDisplayMode = ref(sankeyGraphPossibleDisplayModesList[0].value);
 
-const populatedSankeyChartData = computed(() =>
-  getSankeyData(props.studyData, sankeyDisplayMode.value)
-)
+const populatedSankeyChartData = computed(() => {
+  const { actors, flows } = props.studyData.ecoData;
+  return getSankeyData(actors, flows, {
+    sankeyDisplayMode: sankeyDisplayMode.value,
+    monetaryCurrency: props.studyData.targetCurrency,
+  })
+})
 </script>
 
 <style scoped lang="scss">

--- a/src/components/study/environment/ImpactDataviz.vue
+++ b/src/components/study/environment/ImpactDataviz.vue
@@ -11,9 +11,6 @@
         >
           <div class="flex flex-row w-full justify-evenly mt-6">
               <div class="w-full flex flex-row justify-center">
-<!--
-  <Ring :options="populatedRingChartData"></Ring>
--->
                 <BarChart :options="detailBarChartOptions"></BarChart>
               </div>
           </div>
@@ -53,31 +50,6 @@ const handleDataChartSeriesClick = (event) => {
     selectedValueChain.value = event.name
   }
 }
-
-const populatedRingChartData = computed(() => {
-  var tooltip = {}
-  var items = props.impact.values.filter(item => item.valuechain_name == selectedValueChain.value)
-  .map(item => {
-    tooltip[item.actor_name] = `${formatNumber(item.value)} per functional unit`
-    return {
-      name: item.actor_name,
-      value: item.value,
-      label: {
-          width: 250,
-          overflow: 'break',
-          color: "#e2e0e0",
-          fontSize: 16
-      },
-      labelLine: {
-          length: 40,
-          length2: 10,
-          smooth: true,
-      },
-    }
-  })
-  var series = getRingChart(items, tooltip, "")
-  return series
-})
 
 const detailBarChartOptions = computed(() => {
   var tooltip = {}

--- a/src/components/study/environment/ImpactDataviz.vue
+++ b/src/components/study/environment/ImpactDataviz.vue
@@ -58,7 +58,7 @@ const detailBarChartOptions = computed(() => {
   props.impact.values.filter(item => item.valuechain_name == selectedValueChain.value)
   .forEach(item => {
     labels.push(item.actor_name)
-    var color = getColor(item.actor_name)
+    var color = getColor(item.valuechain_name, true)
     values.push({
         value: item.value,
         itemStyle: {

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -15,7 +15,7 @@ const AVAILABLE_COLORS = {
   HighScoreGreen : "#94D99D",
 }
 
-var FixedColorsMapping = {
+const FixedColorsMapping = {
   Producers: AVAILABLE_COLORS["StageProducerGreen"],
   Collectors: AVAILABLE_COLORS["StageCollectorSalmon"],
   Processors: AVAILABLE_COLORS["StageProcessorRed"],
@@ -29,8 +29,24 @@ var FixedColorsMapping = {
   government: AVAILABLE_COLORS["SubstantialScoreYellow"]
 }
 
-export function getColor(itemName) {
-  return FixedColorsMapping[itemName] || AVAILABLE_COLORS.Grey;
+const DynamicColorsMapping = {};
+
+export function getColor(itemName, isEnvironment) {
+  if (isEnvironment) {
+    return getEnvironmentDynamicColor(itemName);
+  }
+  return FixedColorsMapping[itemName] || AVAILABLE_COLORS.Grey;  
+}
+
+function getEnvironmentDynamicColor(itemName) {
+  return DynamicColorsMapping[itemName] || findNewColor();
+
+  function findNewColor() {
+    const nextColorCode = Object.keys(DynamicColorsMapping).length % Object.keys(AVAILABLE_COLORS).length;
+    var pickedColorName = Object.keys(AVAILABLE_COLORS)[nextColorCode]
+    DynamicColorsMapping[itemName] = AVAILABLE_COLORS[pickedColorName]
+    return DynamicColorsMapping[itemName]
+  }
 }
 
 export const getSocialScoreColor = (value) => {

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -4,6 +4,7 @@ const AVAILABLE_COLORS = {
   StageProcessorRed : "#E06C78",
   StageWholesalerBlue : "#5874DC",
   StageRetailerDarkBlue : "#384E78",
+  StageEndUsePurple: "#9A6AB5",
   Grey : "#CACBCE",
   LightGrey : "#E1DFDF",
   Bronze : "#E5D08F",
@@ -20,6 +21,7 @@ var FixedColorsMapping = {
   Processors: AVAILABLE_COLORS["StageProcessorRed"],
   Wholesalers: AVAILABLE_COLORS["StageWholesalerBlue"],
   Retailers: AVAILABLE_COLORS["StageRetailerDarkBlue"],
+  "End use": AVAILABLE_COLORS["StageEndUsePurple"],
   landOwnersFees: AVAILABLE_COLORS["Bronze"],
   depreciation: AVAILABLE_COLORS["LightBronze"],
   employeeWages:AVAILABLE_COLORS["Grey"],
@@ -40,6 +42,10 @@ export const getColor = (itemName) => {
   console.log("Dynamically added color to item", itemName, pickedColorName)
   DynamicColorsMapping[itemName] = AVAILABLE_COLORS[pickedColorName]
   return DynamicColorsMapping[itemName]
+}
+
+export function getFixedColor(itemName) {
+  return FixedColorsMapping[itemName] || null;
 }
 
 export const getSocialScoreColor = (value) => {

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -29,23 +29,8 @@ var FixedColorsMapping = {
   government: AVAILABLE_COLORS["SubstantialScoreYellow"]
 }
 
-var DynamicColorsMapping = {}
-
-export const getColor = (itemName) => {
-  if (itemName in FixedColorsMapping) {
-    return FixedColorsMapping[itemName]
-  }
-  if (itemName in DynamicColorsMapping) {
-    return DynamicColorsMapping[itemName]
-  }
-  var pickedColorName = Object.keys(AVAILABLE_COLORS)[Object.keys(DynamicColorsMapping).length % Object.keys(AVAILABLE_COLORS).length]
-  console.log("Dynamically added color to item", itemName, pickedColorName)
-  DynamicColorsMapping[itemName] = AVAILABLE_COLORS[pickedColorName]
-  return DynamicColorsMapping[itemName]
-}
-
-export function getFixedColor(itemName) {
-  return FixedColorsMapping[itemName] || null;
+export function getColor(itemName) {
+  return FixedColorsMapping[itemName] || AVAILABLE_COLORS.Grey;
 }
 
 export const getSocialScoreColor = (value) => {


### PR DESCRIPTION
Issue #68

## Contexte

On veut améliorer l'affichage du Sankey. Dans cette PR, je

- [tooltip] Refactor la construction des tooltips
- [legend] Ajoute une légende au Sankey.
  - On affiche les couleurs des stages.
  - J'ajoute une couleur pour le stage `End use` (violet)
- Correction d'un bug de mon algorythme de profondeur
  - La profondeur n'était pas calculée si aucun des actors n'était un Producer
- Suppression de l'algo de `nodeGap`, qui empechait de mettre les flux à l'échelle
- :warning: Je change comment on charge la couleur des stages
  - Toute couleur non identifiée est maintenant grise
  - Celle force les scientifiques à uploader des fichiers avec les  bons labels.
  
| | Avant | Après | 
| - | - | - |
| Coffee Ecuador | ![image](https://github.com/user-attachments/assets/33213115-4c87-4d85-9b47-e4cc151641dc) | ![image](https://github.com/user-attachments/assets/a55cd3b5-9146-47dd-94f6-60ac5bab9e20) |  
| Banane Burundi | ![image](https://github.com/user-attachments/assets/58ecf22f-60f7-4efb-b50d-13cdbd5fdf4e) | ![image](https://github.com/user-attachments/assets/0d449e4b-7035-4819-8bfc-cd30c7324871) |