### PR TITLE
feat(68): Better text format for Sankey

### DIFF
--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { useCurrencyUtils } from '@utils/format.js'
+import { useCurrencyUtils, formatNumber } from '@utils/format.js'
 import { buildDepthByActor } from "./sankeyDepth";
 
 export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurrency }) => {
@@ -58,10 +58,10 @@ export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurren
                     return product;
                 },
             },
-            "Monetary value": monetaryValue,
-            "Volume exchanged (kg Of product)": volumeExchanged,
+            "Monetary value": prettyAmount.value(monetaryValue, monetaryCurrency),
+            "Volume exchanged (kg Of product)": formatNumber(volumeExchanged),
             "Products": product,
-            "Unitary price (local curency)": unitPrice,
+            "Unitary price (local curency)": prettyAmount.value(unitPrice, monetaryCurrency),
             "Volume Unit": volumeUnit,
             "Remark": ''
         };
@@ -80,9 +80,9 @@ export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurren
                 return formatTooltip("Products", {
                   "Source": params.data.source,
                   "Target": params.data.target,
-                  "Monetary value": prettyAmount.value(params.data["Monetary value"], monetaryCurrency),
+                  "Monetary value": params.data["Monetary value"],
                   "Products": params.data['Products'],
-                  "Unitary price (local curency)": prettyAmount.value(params.data['Unitary price (local curency)'], monetaryCurrency),
+                  "Unitary price (local curency)": params.data['Unitary price (local curency)'],
                   "Volume exchanged (kg Of product)": params.data['Volume exchanged (kg Of product)'],
                   "Volume unit": params.data['Volume unit'],
                   "Remark": params.data['Remark'],

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -56,7 +56,7 @@ export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurren
                 show: true,
                 formatter: () => {
                     return product;
-                }
+                },
             },
             "Monetary value": monetaryValue,
             "Volume exchanged (kg Of product)": volumeExchanged,
@@ -72,12 +72,12 @@ export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurren
         formatter: (params) => {
             switch (params?.dataType) {
               case "node":
-                return formatTooltip({
+                return formatTooltip("Name", {
                   "Name": params.data.name,
                   "Stage": findActorStage(actors, params.data.name)
                 });
               case "edge":
-                return formatTooltip({
+                return formatTooltip("Products", {
                   "Source": params.data.source,
                   "Target": params.data.target,
                   "Monetary value": prettyAmount.value(params.data["Monetary value"], monetaryCurrency),
@@ -101,12 +101,23 @@ function findActorStage(actors, actorName) {
   return actor ? actor.stage : undefined;
 }
 
-function formatTooltip(items) {
-  const tooltipItems = Object.entries(items)
-    .map(([itemLabel, itemValue]) => formatTooltipItem(itemLabel, itemValue));
+function formatTooltip(titleKey, items) {
+  let listKeys = Object.keys(items);
+  let title = null;
+  if (listKeys.includes(titleKey)) {
+    title = items[titleKey];
+    listKeys = listKeys.filter(key => key !== titleKey);
+  }
+  const tooltipItems = listKeys
+    .map((itemLabel) => formatTooltipItem(itemLabel, items[itemLabel]));
 
   return `
     <div style='max-width: 400px; white-space: normal;'>
+      ${title ? `
+        <div style='font-size: 16px; margin-bottom: 10px'>
+          <strong>${title}</strong>
+        </div>
+      ` : ``}
       <ul style='list-style: initial; margin: 0 10px; padding: initial;'>
         ${tooltipItems.join('')}
       </ul>

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -45,7 +45,7 @@ export const formatPercent = (amount) => {
 
 export function useCurrencyUtils(props) {
   const prettyAmount = computed(() => (amount) =>
-    `${formatNumber(amount)}${getCurrencySymbol(props.currency)}`
+    `${formatNumber(amount)} ${getCurrencySymbol(props.currency)}`
   );
 
   const convertAmount = computed(() => (amount) =>


### PR DESCRIPTION
Resolves: #68

## Contexte

On veut améliorer le sankey. Après quelques retours de Gaspard et Léonard, je

- Ajoute un titre aux tooltips
- Regle l'affichage des nombres (surtout les devises)

| Avant | Après |
| - | - |
| ![image](https://github.com/user-attachments/assets/b463ae72-7358-48ad-af90-805ac9292cff) | ![image](https://github.com/user-attachments/assets/8ee3a829-b39e-41ba-90fe-6656e419b5d8) |
| ![image](https://github.com/user-attachments/assets/3c32e316-b906-4d8a-950c-44c44b17ca49) | ![image](https://github.com/user-attachments/assets/d7ee737d-8bad-484b-b793-d6358f6e1577) |