### PR TITLE
feat: Add script to rewrite jsons based on imported xlsx data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "tailwindcss": "^3.3.2",
         "typescript-eslint": "^8.3.0",
         "vite": "^4.1.3",
+        "vite-node": "^2.0.5",
         "vue-eslint-parser": "^9.4.3"
       }
     },
@@ -94,6 +95,22 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -777,6 +794,214 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.1.tgz",
+      "integrity": "sha512-2thheikVEuU7ZxFXubPDOtspKn1x0yqaYQwvALVtEcvFhMifPADBrgRPyHV0TF3b+9BgvgjgagVyvA/UqPZHmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.1.tgz",
+      "integrity": "sha512-t1lLYn4V9WgnIFHXy1d2Di/7gyzBWS8G5pQSXdZqfrdCGTwi1VasRMSS81DTYb+avDs/Zz4A6dzERki5oRYz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.1.tgz",
+      "integrity": "sha512-AH/wNWSEEHvs6t4iJ3RANxW5ZCK3fUnmf0gyMxWCesY1AlUj8jY7GC+rQE4wd3gwmZ9XDOpL0kcFnCjtN7FXlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.1.tgz",
+      "integrity": "sha512-dO0BIz/+5ZdkLZrVgQrDdW7m2RkrLwYTh2YMFG9IpBtlC1x1NPNSXkfczhZieOlOLEqgXOFH3wYHB7PmBtf+Bg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.1.tgz",
+      "integrity": "sha512-sWWgdQ1fq+XKrlda8PsMCfut8caFwZBmhYeoehJ05FdI0YZXk6ZyUjWLrIgbR/VgiGycrFKMMgp7eJ69HOF2pQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.1.tgz",
+      "integrity": "sha512-9OIiSuj5EsYQlmwhmFRA0LRO0dRRjdCVZA3hnmZe1rEwRk11Jy3ECGGq3a7RrVEZ0/pCsYWx8jG3IvcrJ6RCew==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.1.tgz",
+      "integrity": "sha512-0kuAkRK4MeIUbzQYu63NrJmfoUVicajoRAL1bpwdYIYRcs57iyIV9NLcuyDyDXE2GiZCL4uhKSYAnyWpjZkWow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.1.tgz",
+      "integrity": "sha512-/6dYC9fZtfEY0vozpc5bx1RP4VrtEOhNQGb0HwvYNwXD1BBbwQ5cKIbUVVU7G2d5WRE90NfB922elN8ASXAJEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.1.tgz",
+      "integrity": "sha512-ltUWy+sHeAh3YZ91NUsV4Xg3uBXAlscQe8ZOXRCVAKLsivGuJsrkawYPUEyCV3DYa9urgJugMLn8Z3Z/6CeyRQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.1.tgz",
+      "integrity": "sha512-BggMndzI7Tlv4/abrgLwa/dxNEMn2gC61DCLrTzw8LkpSKel4o+O+gtjbnkevZ18SKkeN3ihRGPuBxjaetWzWg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.1.tgz",
+      "integrity": "sha512-z/9rtlGd/OMv+gb1mNSjElasMf9yXusAxnRDrBaYB+eS1shFm6/4/xDH1SAISO5729fFKUkJ88TkGPRUh8WSAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.1.tgz",
+      "integrity": "sha512-kXQVcWqDcDKw0S2E0TmhlTLlUgAmMVqPrJZR+KpH/1ZaZhLSl23GZpQVmawBQGVhyP5WXIsIQ/zqbDBBYmxm5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.1.tgz",
+      "integrity": "sha512-CbFv/WMQsSdl+bpX6rVbzR4kAjSSBuDgCqb1l4J68UYsQNalz5wOqLGYj4ZI0thGpyX5kc+LLZ9CL+kpqDovZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.1.tgz",
+      "integrity": "sha512-3Q3brDgA86gHXWHklrwdREKIrIbxC0ZgU8lwpj0eEKGBQH+31uPqr0P2v11pn0tSIxHvcdOWxa4j+YvLNx1i6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.1.tgz",
+      "integrity": "sha512-tNg+jJcKR3Uwe4L0/wY3Ro0H+u3nrb04+tcq1GSYzBEmKLeOQF2emk1whxlzNqb6MMrQ2JOcQEpuuiPLyRcSIw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.1.tgz",
+      "integrity": "sha512-xGiIH95H1zU7naUyTKEyOA/I0aexNMUdO9qRv0bLKN3qu25bBdrxZHqA3PTJ24YNN/GdMzG4xkDcd/GvjuhfLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
@@ -790,6 +1015,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.3.0",
@@ -1385,6 +1616,15 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/callsites": {
@@ -3338,6 +3578,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
     "node_modules/pdfjs-dist": {
       "version": "4.5.136",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.5.136.tgz",
@@ -4193,6 +4439,15 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tippy.js": {
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
@@ -4398,6 +4653,512 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
+      "integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.5",
+        "pathe": "^1.1.2",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/rollup": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.1.tgz",
+      "integrity": "sha512-ZnYyKvscThhgd3M5+Qt3pmhO4jIRR5RGzaSovB6Q7rGNrK5cUncrtLmcTTJVSdcKXyZjW8X8MB0JMSuH9bcAJg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.21.1",
+        "@rollup/rollup-android-arm64": "4.21.1",
+        "@rollup/rollup-darwin-arm64": "4.21.1",
+        "@rollup/rollup-darwin-x64": "4.21.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.21.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.21.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.21.1",
+        "@rollup/rollup-linux-arm64-musl": "4.21.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.21.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.21.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.21.1",
+        "@rollup/rollup-linux-x64-gnu": "4.21.1",
+        "@rollup/rollup-linux-x64-musl": "4.21.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.21.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.21.1",
+        "@rollup/rollup-win32-x64-msvc": "4.21.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.2.tgz",
+      "integrity": "sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.41",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         },
         "stylus": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "tailwindcss": "^3.3.2",
     "typescript-eslint": "^8.3.0",
     "vite": "^4.1.3",
+    "vite-node": "^2.0.5",
     "vue-eslint-parser": "^9.4.3"
   }
 }

--- a/src/components/import/CheckImportedDataStep.vue
+++ b/src/components/import/CheckImportedDataStep.vue
@@ -130,7 +130,7 @@ import { slugify } from '@utils/format.js'
 
 import { ACV_SHEET_NAMES } from '@utils/import/environment.js'
 import { getImportErrors } from '@utils/import/generic.js'
-import { ECO_SHEET_NAMES, HOME_LABELS, getErrors } from '@utils/import/eco.js'
+import { ECO_SHEET_NAMES, HOME_LABELS } from '@utils/import/eco.js'
 
 const props = defineProps({
   studyData: Object
@@ -160,9 +160,7 @@ const isKnownProduct = computed(() =>
 const errorsBySpreadsheet = computed(() => {
   console.log('errorsBySpreadsheet computation trigger')
   let result = {}
-  let rawErrors = null
   if (props.studyData.type === 'eco') {
-    rawErrors = getErrors(props.studyData)
     Object.keys(ECO_SHEET_NAMES).forEach((spreadsheetName) => {
       result[ECO_SHEET_NAMES[spreadsheetName]] = []
     })
@@ -172,9 +170,8 @@ const errorsBySpreadsheet = computed(() => {
         result[ACV_SHEET_NAMES[spreadsheetName]] = []
       })
     }
-    rawErrors = getImportErrors()
   }
-  rawErrors.forEach((error) => {
+  getImportErrors().forEach((error) => {
     if (!result[error.spreadsheet]) {
       result[error.spreadsheet] = []
     }

--- a/src/components/import/CheckImportedDataStep.vue
+++ b/src/components/import/CheckImportedDataStep.vue
@@ -129,11 +129,11 @@ import { getCountries, getAllKnownProducts } from '@utils/data'
 import { slugify } from '@utils/format.js'
 
 import { ACV_SHEET_NAMES } from '@utils/import/environment.js'
-import { getImportErrors } from '@utils/import/generic.js'
 import { ECO_SHEET_NAMES, HOME_LABELS } from '@utils/import/eco.js'
 
 const props = defineProps({
-  studyData: Object
+  studyData: Object,
+  importErrors: Array,
 })
 
 const TypesOfFile = {
@@ -171,7 +171,7 @@ const errorsBySpreadsheet = computed(() => {
       })
     }
   }
-  getImportErrors().forEach((error) => {
+  props.importErrors.forEach((error) => {
     if (!result[error.spreadsheet]) {
       result[error.spreadsheet] = []
     }

--- a/src/components/import/SaveOnGithubStep.vue
+++ b/src/components/import/SaveOnGithubStep.vue
@@ -31,7 +31,7 @@ import upload_files_screenshot from '@images/tuto_upload/upload_files_on_github.
 import commit_creation_screenshot from '@images/tuto_upload/commit_creation_screenshot.png'
 
 const props = defineProps({
-  studyData: Object
+  studyData: Object,
 })
 
 const jsonFile = computed(() => {

--- a/src/components/import/SaveOnGithubStep.vue
+++ b/src/components/import/SaveOnGithubStep.vue
@@ -21,11 +21,10 @@
 </template>
 
 <script setup>
-import _ from "lodash";
 import { computed } from 'vue';
 
 import jsonData from '@data/data.json'
-import { slugify } from '@utils/format.js'
+import { amendDataFile } from "@utils/import/generic";
 
 import upload_files_screenshot from '@images/tuto_upload/upload_files_on_github.png'
 import commit_creation_screenshot from '@images/tuto_upload/commit_creation_screenshot.png'
@@ -52,66 +51,8 @@ const studyFileName = computed(() => {
 })
 
 const dataFile = computed(() => {
-    if (!jsonData.studies.find(study => study.id === props.studyData.id)) {
-        jsonData.studies.push({
-            id: `${props.studyData.id}`,
-            title: `${props.studyData.country} ${props.studyData.commodity}`,
-            year: props.studyData.year,
-            country: props.studyData.country.toLowerCase(),
-            product: props.studyData.commodity.toLowerCase()
-        })
-    }
-    jsonData.studies.sort(sortFunctionByProperties(["country", "product"]));
-  
-    const slugifiedCountry = slugify(props.studyData.country)
-    if (!jsonData.countries.find(country => country.id === slugifiedCountry)) {
-        jsonData.countries.push({
-            id: slugifiedCountry,
-            prettyName: props.studyData.country
-        })
-    }
-    jsonData.countries.sort(sortFunctionByProperties(["id"]));
-
-    const existingCommodities = jsonData.categories.reduce((arr, current) => arr.concat(current.commodities), [])
-    const slugifiedCommodity = slugify(props.studyData.commodity)
-    if (!existingCommodities.includes(slugifiedCommodity)) {
-        jsonData.categories.find(category => category.id === 'unknown').commodities.push(slugifiedCommodity)
-    }
-
-    jsonData.products = updateProductList(jsonData.products, existingCommodities);
-
-    return JSON.stringify(
-        jsonData
-        , null, 2)
+    return amendDataFile(jsonData, props.studyData)
 })
-
-function sortFunctionByProperties(propertyKeys) {
-  return function(itemA, itemB) {
-    for (var key of propertyKeys) {
-      if (itemA[key] < itemB[key]) {
-          return -1
-      }
-      else if (itemA[key] > itemB[key]) {
-          return 1
-      }
-    }
-    return 0;
-  }
-}
-
-function updateProductList(products = [], existingProductKeys) {
-  const newProducts = [...products];
-  existingProductKeys.forEach(productKey => {
-    if (!products.find(product => product.id === productKey)) {
-      newProducts.push({
-        id: productKey,
-        prettyName: _.capitalize(productKey) 
-      });
-    }
-  });
-  newProducts.sort(sortFunctionByProperties("id"));
-  return newProducts;
-}
 
 const downloadFile = (data, fileName) => {
   const blob = new Blob([data], { type: 'application/json' })

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -55,7 +55,6 @@ export const isValidCurrency = (ccy) => {
       currency: ccy
     })
   } catch {
-    console.log(`Given currency is not standard: ${ccy}`)
     return false
   }
   return true

--- a/src/utils/import/eco.js
+++ b/src/utils/import/eco.js
@@ -552,7 +552,6 @@ export const checksActorsAreKnown = (ecoData) => {
 
   const actorNames = ecoData.actors.map(actor => actor.name)
   let unknownActorsInFlows = []
-  console.log(ecoData.flows, actorNames);
   unknownActorsInFlows = unknownActorsInFlows.concat(ecoData.flows.filter(flow => !actorNames.includes(flow.buyerActorName)).reduce((arr, flow) => arr.concat(flow.buyerActorName), []))
   unknownActorsInFlows = unknownActorsInFlows.concat(ecoData.flows.filter(flow => !actorNames.includes(flow.sellerActorName)).reduce((arr, flow) => arr.concat(flow.buyerActorName), []))
   unknownActorsInFlows.map(actor => {

--- a/src/utils/import/eco.js
+++ b/src/utils/import/eco.js
@@ -338,8 +338,6 @@ const parseEmploymentSheet = (json, actors) => {
     return result
   })
 
-  console.log("voici les données d'emplois", employments)
-
   actors = actors.map(actor => {
     let employment = employments.filter(employment => employment.actorName === actor.name)
     if (employment && employment.length === 1) {

--- a/src/utils/import/environment.js
+++ b/src/utils/import/environment.js
@@ -120,7 +120,6 @@ const parseImpacts = (json, valueChains, actors) => {
   if (sheetAsJson == null) {
     return null
   }
-  console.log("plan de travail pour les impacts", sheetAsJson)
   var rowCount = 0
   var dictionnaire_chain_actors_props = {}
   var firstRow = null
@@ -170,15 +169,12 @@ const parseImpacts = (json, valueChains, actors) => {
 
 export const parseEnvironmentJson = (json) => {
   let valuechains = parseValueChainsDescriptions(json)
-  console.log("value chains:", valuechains)
   
   let actors = parseActorTypes(json)
-  console.log("actors:", actors)
 
   parseActorsAndChainsMatrix(json, valuechains, actors)
 
   var impacts = parseImpacts(json, valuechains, actors)
-  console.log("impacts:", impacts)
   return {
     valuechains,
     actors,

--- a/src/utils/import/generic.js
+++ b/src/utils/import/generic.js
@@ -25,7 +25,6 @@ export const ErrorLevels = Object.freeze({
 })
 
 export const setImportErrors = (spreadsheet, level, message) => {
-  console.log("Following error during import :", message)
   ImportErrors.push({
     level: level,
     spreadsheet: spreadsheet,
@@ -158,7 +157,6 @@ export const processUploadedExcelFile = (workbook) => {
 
   let excelData = {}
   workbook.SheetNames.forEach((workSheet) => {
-    console.log("Converting to JSON sheet", workSheet)
     const rowObject = XLSX.utils.sheet_to_json(
       workbook.Sheets[workSheet]
     )

--- a/src/utils/import/generic.js
+++ b/src/utils/import/generic.js
@@ -231,12 +231,13 @@ export function amendDataFile(jsonData, studyData) {
     }
     jsonData.countries.sort(sortFunctionByProperties(["id"]));
 
-    const existingCommodities = jsonData.categories.reduce((arr, current) => arr.concat(current.commodities), [])
+    const existingCommoditiesInCategories = jsonData.categories.reduce((arr, current) => arr.concat(current.commodities), [])
     const slugifiedCommodity = slugify(studyData.commodity)
-    if (!existingCommodities.includes(slugifiedCommodity)) {
+    if (!existingCommoditiesInCategories.includes(slugifiedCommodity)) {
         jsonData.categories.find(category => category.id === 'unknown').commodities.push(slugifiedCommodity)
     }
 
+    const existingCommodities = _.uniq(jsonData.studies.map(study => study.product));
     jsonData.products = updateProductList(jsonData.products, existingCommodities);
 
     return JSON.stringify(

--- a/src/utils/scripts/parseStudyXlsx.js
+++ b/src/utils/scripts/parseStudyXlsx.js
@@ -7,14 +7,19 @@ parseStudyXlsx(process.argv[2]);
 
 function parseStudyXlsx(xlsxPath) {
   const xlsx = findFile(xlsxPath);
-  // WIP
-  processFile(xlsx);
+  const jsonData = processFile(xlsx);
+
+  fs.writeFileSync(buildJsonPath(xlsxPath), stringifyJson(jsonData));
 }
 
-function processFile(xlsx) {
-  const { data, errors } = processUploadedExcelFile(xlsx);
+function processFile(xlsxPath) {
+  const { data, errors } = processUploadedExcelFile(xlsxPath);
   logErrors(errors);
   return data;
+}
+
+function buildJsonPath(xlsxPath) {
+  return xlsxPath.replace(/\.xlsx$/, ".json");
 }
 
 function logErrors(errors) {
@@ -23,6 +28,10 @@ function logErrors(errors) {
     console.log(error.message);
     console.log("");
   })
+}
+
+function stringifyJson(jsonData) {
+  return JSON.stringify(jsonData, null, 2);
 }
 function findFile(xlsxPath) {
   const file = fs.readFileSync(xlsxPath);

--- a/src/utils/scripts/parseStudyXlsx.js
+++ b/src/utils/scripts/parseStudyXlsx.js
@@ -1,0 +1,17 @@
+/* global process */
+import { processUploadedExcelFile } from "@utils/import/generic.js";
+import * as XLSX from 'xlsx';
+import fs from "fs";
+
+parseStudyXlsx(process.argv[2]);
+
+function parseStudyXlsx(xlsxPath) {
+  const xlsx = findFile(xlsxPath);
+  // WIP
+  console.log(processUploadedExcelFile(xlsx));
+}
+
+function findFile(xlsxPath) {
+  const file = fs.readFileSync(xlsxPath);
+  return XLSX.read(file);
+}

--- a/src/utils/scripts/parseStudyXlsx.js
+++ b/src/utils/scripts/parseStudyXlsx.js
@@ -8,9 +8,22 @@ parseStudyXlsx(process.argv[2]);
 function parseStudyXlsx(xlsxPath) {
   const xlsx = findFile(xlsxPath);
   // WIP
-  console.log(processUploadedExcelFile(xlsx));
+  processFile(xlsx);
 }
 
+function processFile(xlsx) {
+  const { data, errors } = processUploadedExcelFile(xlsx);
+  logErrors(errors);
+  return data;
+}
+
+function logErrors(errors) {
+  errors.forEach(error => {
+    console.log(`Error[${error.level}] on spreadsheet "${error.spreadsheet}":`);
+    console.log(error.message);
+    console.log("");
+  })
+}
 function findFile(xlsxPath) {
   const file = fs.readFileSync(xlsxPath);
   return XLSX.read(file);

--- a/src/utils/scripts/parseStudyXlsx.js
+++ b/src/utils/scripts/parseStudyXlsx.js
@@ -9,15 +9,19 @@ function parseStudyXlsx(...args) {
   if (args[0] === "--all") {
     processAllFiles(args[1])
   } else {
-    processFile(args[0]);
+    processSingleFile(args[0]);
   }
 }
-
 
 function processAllFiles(dirPath) {
   const filePaths = findAllFilesPaths(dirPath);
 
-  filePaths.forEach(filePath => processFile(`${dirPath}/${filePath}`));
+  filePaths.forEach(filePath => {
+    const { errors } = processFile(`${dirPath}/${filePath}`);
+    if (errors.length !== 0) {
+      console.log(`${errors.length} errors on ${filePath}`);
+    }
+  });
 }
 
 function findAllFilesPaths(rootPath) {
@@ -33,18 +37,18 @@ function findAllFilesPaths(rootPath) {
   }
 }
 
-function processFile(xlsxPath) {
-  const file = findFile(xlsxPath);
-  const jsonData = computeJsonData(file);
-
-  fs.writeFileSync(buildJsonPath(xlsxPath), stringifyJson(jsonData));
+function processSingleFile(xlsxPath) {
+  const { errors } = processFile(xlsxPath);
+  logErrors(errors);
 }
 
-function computeJsonData(file) {
-  const { data, errors } = processUploadedExcelFile(file);
-  logErrors(errors);
+function processFile(xlsxPath) {
+  const file = findFile(xlsxPath);
+  const { data: jsonData, errors } = processUploadedExcelFile(file);
 
-  return data;
+  fs.writeFileSync(buildJsonPath(xlsxPath), stringifyJson(jsonData));
+
+  return { errors };
 }
 
 function buildJsonPath(xlsxPath) {

--- a/src/utils/scripts/parseStudyXlsx.js
+++ b/src/utils/scripts/parseStudyXlsx.js
@@ -1,7 +1,11 @@
-/* global process */
+/* global process __dirname */
 import { processUploadedExcelFile } from "@utils/import/generic.js";
 import * as XLSX from 'xlsx';
 import fs from "fs";
+import { amendDataFile } from "../import/generic";
+import jsonData from "../../../data/data.json";
+
+const DATA_JSON_PATH = `${__dirname}/../../../data/data.json`;
 
 parseStudyXlsx(...process.argv.slice(2));
 
@@ -44,9 +48,11 @@ function processSingleFile(xlsxPath) {
 
 function processFile(xlsxPath) {
   const file = findFile(xlsxPath);
-  const { data: jsonData, errors } = processUploadedExcelFile(file);
+  const { data: studyData, errors } = processUploadedExcelFile(file);
+  const newDataJson = amendDataFile(jsonData, studyData)
 
-  fs.writeFileSync(buildJsonPath(xlsxPath), stringifyJson(jsonData));
+  fs.writeFileSync(buildJsonPath(xlsxPath), stringifyJson(studyData));
+  fs.writeFileSync(DATA_JSON_PATH, newDataJson);
 
   return { errors };
 }


### PR DESCRIPTION
Ticket: #53 

## Contexte

On veut changer la facon dont on importe les données

Pour mettre à jour plus rapidement les json (et pour tout bug d'import futur), on construit dans cette PR un script qui calcule les json (d'études, + `data.json`) a partir des xlslx (soirt 1 à 1, soit tous d'un coup)

## Plan de PR

- :dart **Cette PR**: Création du script
- Réparation de la logique d'import / des données json: L'execution du script modifie plein de données :confused: 
- Modification de l'import des données d'emplois

## Commit split

- Un peu de refacto de la logique de parsing dans `/import` qui retourne les erreur (pour les afficher dans le script)
- Création du script
  - Récupération des fichier, et processing
  - Ecriture dans les fichier json en local directement
  - Option "compute all" pour tout faire en batch
- Ecriture dans `data.json` également au traitement de chaque fichier