### PR TITLE
fix(82): feedbacks

### DIFF
--- a/src/components/StudyOverview.vue
+++ b/src/components/StudyOverview.vue
@@ -59,12 +59,6 @@
       v-if="studyUrls.briefPdf"
       :studyBriefUrl="studyUrls.briefPdf"
     />
-    <a
-      v-if="studyUrls.fullPdf"
-      target="_blank"
-      class="text-blue-600"
-      :href="studyUrls.fullPdf"
-    >Download study full report</a>
     <section v-if="studyData && studyData.ecoData">
       <Sankey :studyData="studyData" />
     </section>

--- a/src/components/study/DownloadSection.vue
+++ b/src/components/study/DownloadSection.vue
@@ -11,7 +11,7 @@
           :key="urlKey"
           class="url-item"
         >
-          <a class="url-title" :href="link">{{ title }}</a>
+          <a class="url-title" target="_blank" :href="link">{{ title }}</a>
           <span v-if="subtitle" class="url-subtitle">{{ subtitle }}</span>
         </div>
       </div>


### PR DESCRIPTION
Ticket: #82

## Changements

- Je supprime le lien vers le pdf complet sous la preview du résumé (comme décide ensemble)
- Fix: Je rajoute `target="_blank"` dans le downlad center pour éviter de remplacer la tab actuelle quand on lit des pdf