### PR TITLE
feat: Add no-console eslint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,12 @@ export default [
   ...pluginVue.configs['flat/recommended'],
   ...tseslint.configs.recommended,
   {
+    files: ["**/*.vue", "**/*.js"],
+    rules: {
+      "no-console": ["error", { allow: ["warn", "error"] }]
+    }
+  },
+  {
     files: ["**/*.vue"],
     languageOptions: {
       parser: vueParser,

--- a/src/charts/sankey.js
+++ b/src/charts/sankey.js
@@ -92,7 +92,6 @@ export const getSankeyData = (actors, flows, { sankeyDisplayMode, monetaryCurren
             }
         }
     };
-    console.log("sankey chart options:", result)
     return result;
 }
 

--- a/src/components/import/CheckImportedDataStep.vue
+++ b/src/components/import/CheckImportedDataStep.vue
@@ -158,7 +158,6 @@ const isKnownProduct = computed(() =>
 )
 
 const errorsBySpreadsheet = computed(() => {
-  console.log('errorsBySpreadsheet computation trigger')
   let result = {}
   if (props.studyData.type === 'eco') {
     Object.keys(ECO_SHEET_NAMES).forEach((spreadsheetName) => {
@@ -177,7 +176,6 @@ const errorsBySpreadsheet = computed(() => {
     }
     result[error.spreadsheet].push(error)
   })
-  console.log('error to display', result)
   return result
 })
 </script>

--- a/src/components/study/economic-growth/BalanceOfTrade.vue
+++ b/src/components/study/economic-growth/BalanceOfTrade.vue
@@ -103,7 +103,6 @@ const optionsImported = computed(() => {
     prettyAmount.value,
     convertAmount.value
   )
-  console.log('option pour iported', result)
   return result
 })
 const optionsExported = computed(() => {

--- a/src/components/study/social-sustainability/SocialDetails.vue
+++ b/src/components/study/social-sustainability/SocialDetails.vue
@@ -44,7 +44,6 @@ let tooltipTexts = {
 }
 
 function getTooltipText(partName) {
-    console.log(partName)
     return tooltipTexts[partName]
 }
 </script>

--- a/src/components/study/social-sustainability/SocialRadar.vue
+++ b/src/components/study/social-sustainability/SocialRadar.vue
@@ -57,8 +57,7 @@ const chartData = computed(() => {
       },
       axisName: {
         show: false,
-        formatter: function (value, param) {
-            console.log("value", value, param)
+        formatter: function (value) {
           return value
         },
         fontWeight: 'bold',

--- a/src/repositories/basicApi.js
+++ b/src/repositories/basicApi.js
@@ -18,7 +18,7 @@ async function serverCall(url) {
   try {
     var results = await apiClient.get(url);
   } catch (error) {
-    console.log("serverCall Error", error, "on url", url);
+    console.error("serverCall Error", error, "on url", url);
     return null
   }
   Homemade_Cache[url] = results ? results.data : null;

--- a/src/utils/data/studyData.js
+++ b/src/utils/data/studyData.js
@@ -53,6 +53,7 @@ export function logMissingData(studiesData) {
     .map(inventoryMissingData)
     .filter(hasMissingData);
   
+  // eslint-disable-next-line no-console
   console.log(formatReport(studiesWithMissingData));
 }
 function inventoryMissingData(studyData) {

--- a/src/utils/data/uploads.js
+++ b/src/utils/data/uploads.js
@@ -21,7 +21,6 @@ async function getStudyFileAttachmentUrl(studyId, attachementType) {
       studiesAttachment[studyId][attachementType] = attachmentUrl;
     }
     else {
-      console.log("got status", res.status, "for attachment", attachmentUrl)
       studiesAttachment[studyId][attachementType] = null;
     }
   }

--- a/src/utils/scripts/parseStudyXlsx.js
+++ b/src/utils/scripts/parseStudyXlsx.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* global process __dirname */
 import { processUploadedExcelFile } from "@utils/import/generic.js";
 import * as XLSX from 'xlsx';

--- a/src/views/Import.vue
+++ b/src/views/Import.vue
@@ -40,7 +40,6 @@ import { processUploadedExcelFile } from '@utils/import/generic.js'
 const workbook = ref(null)
 
 const clearData = () => {
-    console.log("clearing all data")
     localStorage.removeItem('localWorkbook')
     localStorage.removeItem('localStudyData')
     workbook.value = null
@@ -78,7 +77,6 @@ const importErrors = ref([]);
 const studyData = ref(null);
 
 watch(() => workbook.value, () => {
-    console.log("studyData computation trigger")
     if (!workbook.value) {
         studyData.value = null;
         importErrors.value = [];
@@ -86,7 +84,6 @@ watch(() => workbook.value, () => {
     }
 
     let { data, errors } = processUploadedExcelFile(workbook.value)
-    console.log("studyData new value", data)
     localStorage.setItem('localStudyData', JSON.stringify(data))
     studyData.value = data;
     importErrors.value = errors;


### PR DESCRIPTION
## Contexte

Afin de ne plus oublier des logs de debug, on ajoute une regle eslint

On regle les erreurs actuelles

- Certains logs sont valides, on peut utiliser `console.error` ou désactiver la regle selon le besoin
- On supprime les logs qui ne servent à rien en production