### PR TITLE
fix: Disallow local font

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -7,7 +7,76 @@
 
 
 /* https://fonts.cdnfonts.com/css/source-sans-pro */
-@font-face{font-family:source sans pro;font-style:normal;font-weight:400;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Regular.woff) format('woff')}@font-face{font-family:source sans pro;font-style:italic;font-weight:400;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-It.woff) format('woff')}@font-face{font-family:source sans pro;font-style:normal;font-weight:200;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-ExtraLight.woff) format('woff')}@font-face{font-family:source sans pro;font-style:italic;font-weight:200;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-ExtraLightIt.woff) format('woff')}@font-face{font-family:source sans pro;font-style:normal;font-weight:300;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Light.woff) format('woff')}@font-face{font-family:source sans pro;font-style:italic;font-weight:300;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-LightIt.woff) format('woff')}@font-face{font-family:source sans pro;font-style:normal;font-weight:600;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Semibold.woff) format('woff')}@font-face{font-family:source sans pro;font-style:italic;font-weight:600;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-SemiboldIt.woff) format('woff')}@font-face{font-family:source sans pro;font-style:normal;font-weight:700;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Bold.woff) format('woff')}@font-face{font-family:source sans pro;font-style:italic;font-weight:700;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-BoldIt.woff) format('woff')}@font-face{font-family:source sans pro;font-style:normal;font-weight:900;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Black.woff) format('woff')}@font-face{font-family:source sans pro;font-style:italic;font-weight:900;src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-BlackIt.woff) format('woff')}
+@font-face{
+  font-family:source sans pro;
+  font-style:normal;
+  font-weight:400;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Regular.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:italic;
+  font-weight:400;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-It.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:normal;
+  font-weight:200;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-ExtraLight.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:italic;
+  font-weight:200;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-ExtraLightIt.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:normal;
+  font-weight:300;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Light.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:italic;
+  font-weight:300;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-LightIt.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:normal;
+  font-weight:600;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Semibold.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:italic;
+  font-weight:600;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-SemiboldIt.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:normal;
+  font-weight:700;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Bold.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:italic;
+  font-weight:700;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-BoldIt.woff) format('woff')
+}
+@font-face{font-family:source sans pro;
+  font-style:normal;
+  font-weight:900;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Black.woff) format('woff')
+}
+@font-face{
+  font-family:source sans pro;
+  font-style:italic;font-weight:900;
+  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-BlackIt.woff) format('woff')
+}
 
 
 body {

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -7,75 +7,76 @@
 
 
 /* https://fonts.cdnfonts.com/css/source-sans-pro */
+/* Updated without the local reference, see https://github.com/leonarf/VCA4D/pull/108 */
 @font-face{
   font-family:source sans pro;
   font-style:normal;
   font-weight:400;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Regular.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Regular.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:italic;
   font-weight:400;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-It.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-It.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:normal;
   font-weight:200;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-ExtraLight.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-ExtraLight.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:italic;
   font-weight:200;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-ExtraLightIt.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-ExtraLightIt.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:normal;
   font-weight:300;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Light.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Light.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:italic;
   font-weight:300;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-LightIt.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-LightIt.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:normal;
   font-weight:600;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Semibold.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Semibold.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:italic;
   font-weight:600;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-SemiboldIt.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-SemiboldIt.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:normal;
   font-weight:700;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Bold.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Bold.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:italic;
   font-weight:700;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-BoldIt.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-BoldIt.woff) format('woff')
 }
 @font-face{font-family:source sans pro;
   font-style:normal;
   font-weight:900;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Black.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-Black.woff) format('woff')
 }
 @font-face{
   font-family:source sans pro;
   font-style:italic;font-weight:900;
-  src:local('Source Sans Pro'),url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-BlackIt.woff) format('woff')
+  src:url(https://fonts.cdnfonts.com/s/12183/SourceSansPro-BlackIt.woff) format('woff')
 }
 
 


### PR DESCRIPTION
## Contexte

certaines personnes qui ont la police Basic (`Source Sans Pro`) en local ne voient pas le gras dans les textes

la raison est que le css leur fait prendre leur version locale de "Source Sans pro" sans es variantes grasses.

## Changement

On oblige tous les utilisateurs à télécharger la police de caractères