### PR TITLE
feat(110): Revise comparison indicators

### DIFF
--- a/src/charts/charts.js
+++ b/src/charts/charts.js
@@ -1,5 +1,4 @@
 import { formatNumber, formatPercent } from '@utils/format.js'
-import _ from "lodash";
 import { getColor } from '@utils/colors.js'
 const RADIUSES_MINI_PIE = ['20%', '40%']
 const RIADUSES_PIE = ['50%', '75%']
@@ -227,42 +226,6 @@ export const getNetOperatingProfitData = (stages, actors, convertAmount, prettyA
         }
     }).filter(item => !!item)
     return getSelectableBarChart(items, currentStage.value, tooltip, (value) => `${prettyAmount.value(value)} (${formatPercent(value / total)})`)
-}
-
-export const getNetOperatingProfitByNumberActorsData = (stages, actors, convertAmount, prettyAmount, currentStage) => {
-    const netOperatingProfitPerActorByStage = {};
-    stages.value.forEach(stage => {
-      const stageActors = actors.value.filter(actor => actor.stage === stage.name)
-      const subTotalOperatingProfit = _.sumBy(stageActors, actor => actor.netOperatingProfit || 0);
-      const subTotalNumberOfActors = _.sumBy(stageActors, actor => actor.numberOfActors || 0);
-      const partialStageActors = stageActors.map(actor => ({
-        name: actor.name,
-        netOperatingProfit: actor.netOperatingProfit,
-        numberOfActors: actor.numberOfActors,
-      }));
-
-      if (subTotalOperatingProfit !== 0 && subTotalNumberOfActors !== 0) {
-        netOperatingProfitPerActorByStage[stage.name] = {
-          profitPerActor: subTotalOperatingProfit / subTotalNumberOfActors,
-          stageActors: partialStageActors
-        }
-      }
-    });
-    let tooltip = {}
-
-    const items = Object.entries(netOperatingProfitPerActorByStage).map(([stageName, { profitPerActor, stageActors }]) => {
-      let toolTipValue = ""
-      for (const actor of stageActors) {
-          toolTipValue += `${actor.name}: net operating profit= ${prettyAmount.value(convertAmount.value(actor.netOperatingProfit))} -- #actors= ${formatNumber(actor.numberOfActors)}<br>`
-      }
-      tooltip[stageName] = toolTipValue
-      return {
-          name: stageName,
-          value: convertAmount.value(profitPerActor)
-      }
-    });
-
-    return getSelectableBarChart(items, currentStage.value, tooltip, prettyAmount.value, currentStage)
 }
 
 export const getPublicFinancesData = (stages, actors, convertAmount, prettyAmount, currentStage) => {

--- a/src/charts/charts.js
+++ b/src/charts/charts.js
@@ -234,8 +234,8 @@ export const getNetOperatingProfitByNumberActorsData = (stages, actors, convertA
 
     const items = stages.value.map(stage => {
         const stageActors = actors.value.filter(actor => actor.stage === stage.name)
-        const subTotalOperatingProfit = convertAmount.value(stageActors
-            .reduce((res, actor) => res + actor.netOperatingProfit || 0, 0))
+        const subTotalOperatingProfit = stageActors
+            .reduce((res, actor) => res + actor.netOperatingProfit || 0, 0)
         const subTotalNumberOfActors = stageActors
             .reduce((res, actor) => res + actor.numberOfActors || 0, 0)
         if (subTotalOperatingProfit !== 0 && subTotalNumberOfActors !== 0) {
@@ -246,7 +246,7 @@ export const getNetOperatingProfitByNumberActorsData = (stages, actors, convertA
             tooltip[stage.name] = toolTipValue
             return {
                 name: stage.name,
-                value: subTotalOperatingProfit / subTotalNumberOfActors
+                value: convertAmount.value(subTotalOperatingProfit) / subTotalNumberOfActors
             }
         }
     }).filter(item => !!item)

--- a/src/components/comparison/ComparisonDefaultCell.vue
+++ b/src/components/comparison/ComparisonDefaultCell.vue
@@ -7,12 +7,15 @@
 <script setup>
 import { computed } from 'vue';
 import { formatNumber, formatPercent } from '@utils/format.js'
+import { useCurrencyUtils } from '../../utils/format';
 
 const props = defineProps({
     value: Number,
+    studyData: Object,
+    currency: String,
     valueType: {
       type: String,
-      validator: (valueType) => ["percent", "number"].includes(valueType)
+      validator: (valueType) => ["amount", "percent", "number"].includes(valueType)
     }
 })
 
@@ -22,6 +25,8 @@ const valueClass = computed(() => {
   }
   return "blue";
 });
+
+const { prettyAmount, convertAmount } = useCurrencyUtils(props)
 
 const formatedValue = computed(() => {
   if (! props.value && typeof props.value !== "number") {
@@ -33,6 +38,8 @@ const formatedValue = computed(() => {
       return formatPercent(props.value);
     case "number":
       return formatNumber(props.value);
+    case "amount":
+      return prettyAmount.value(convertAmount.value(props.value));
     default:
       throw new Error("Unrecognized valueType");
   }

--- a/src/components/comparison/ComparisonDefaultCell.vue
+++ b/src/components/comparison/ComparisonDefaultCell.vue
@@ -6,13 +6,13 @@
 
 <script setup>
 import { computed } from 'vue';
-import { formatNumber, formatPercent } from '@utils/format.js'
-import { useCurrencyUtils } from '../../utils/format';
+import { formatNumber, formatPercent, useCurrencyUtils } from '@utils/format.js'
+import { isCurrencySupported } from "@utils/currency";
 
 const props = defineProps({
     value: Number,
     studyData: Object,
-    currency: String,
+    preferredCurrency: String,
     valueType: {
       type: String,
       validator: (valueType) => ["amount", "percent", "number"].includes(valueType)
@@ -20,13 +20,20 @@ const props = defineProps({
 })
 
 const valueClass = computed(() => {
-  if (! props.value) {
-      return "gray"
-  }
+  if (! props.value) { return "gray" }
   return "blue";
 });
 
-const { prettyAmount, convertAmount } = useCurrencyUtils(props)
+const displayCurrency = computed(() => {
+  if(props.valueType !== "amount") { return "USD"; }
+  
+  return isCurrencySupported(props.studyData.targetCurrency) ? props.preferredCurrency : props.studyData.targetCurrency;
+});
+
+const { prettyAmount, convertAmount } = useCurrencyUtils({
+  studyData: props.studyData,
+  currency: displayCurrency.value
+});
 
 const formatedValue = computed(() => {
   if (! props.value && typeof props.value !== "number") {
@@ -44,6 +51,8 @@ const formatedValue = computed(() => {
       throw new Error("Unrecognized valueType");
   }
 });
+
+
 </script>
 
 <style scoped lang="scss">

--- a/src/components/comparison/ComparisonDefaultCell.vue
+++ b/src/components/comparison/ComparisonDefaultCell.vue
@@ -10,23 +10,18 @@ import { formatNumber, formatPercent } from '@utils/format.js'
 
 const props = defineProps({
     value: Number,
-    reverseColors: Boolean,
     valueType: {
       type: String,
       validator: (valueType) => ["percent", "number"].includes(valueType)
     }
 })
 
-const valueClass = computed(() => getPositiveOrNegativeClass(props.reverseColors ? -props.value : props.value))
-function getPositiveOrNegativeClass(value) {
-  if (!value) {
+const valueClass = computed(() => {
+  if (! props.value) {
       return "gray"
   }
-  if (value < 0) {
-      return "negative"
-  }
-  return "positive"
-}
+  return "blue";
+});
 
 const formatedValue = computed(() => {
   if (! props.value && typeof props.value !== "number") {
@@ -48,10 +43,7 @@ const formatedValue = computed(() => {
     .gray {
       @apply bg-gray-300 text-gray-500
     }
-    .negative {
-        background-color: #ffac9e;
-    }
-    .positive {
-        background-color: #94d99d;
+    .blue {
+        background-color: #A4CAFE;
     }
 </style>

--- a/src/components/comparison/ComparisonDefaultCell.vue
+++ b/src/components/comparison/ComparisonDefaultCell.vue
@@ -25,7 +25,7 @@ const valueClass = computed(() => {
 });
 
 const displayCurrency = computed(() => {
-  if(props.valueType !== "amount") { return "USD"; }
+  if(props.valueType !== "amount") { return null; }
   
   return isCurrencySupported(props.studyData.targetCurrency) ? props.preferredCurrency : props.studyData.targetCurrency;
 });

--- a/src/components/comparison/ComparisonEconomics.vue
+++ b/src/components/comparison/ComparisonEconomics.vue
@@ -1,9 +1,32 @@
 <template>
   <ComparisonTitle title="Macro-Economic Indicators" :studies="studies" />
+
+  <ComparisonRow 
+    :studies="studies" 
+    title="Share of national GDP" 
+    subtitle="Value chain GDP divided by national GDP" 
+    :getValue="(study) => study.ecoData?.macroData?.valueAddedShareNationalGdp"
+  >
+    <template #default="{ value }">
+      <ComparisonDefaultCell :value="value" valueType="percent" />
+    </template>
+  </ComparisonRow>
+
+  <ComparisonRow 
+    :studies="studies" 
+    title="Share of agricultural GDP" 
+    subtitle="Value chain GDP divided by agricultural GDP" 
+    :getValue="(study) => study.ecoData?.macroData?.valueAddedShareAgriculturalGdp"
+  >
+    <template #default="{ value }">
+      <ComparisonDefaultCell :value="value" valueType="percent" />
+    </template>
+  </ComparisonRow>
+
   <ComparisonRow 
     :studies="studies" 
     title="Value added" 
-    subtitle="Definition of total value added" 
+    subtitle="Total value added of value chain" 
     :getValue="getTotalAddedValue"
   >
     <template #default="{ value }">
@@ -11,6 +34,18 @@
     </template>
   </ComparisonRow>
 
+  <ComparisonRow 
+    :studies="studies" 
+    title="Rate of Integration" 
+    subtitle="Below 70%: depends on imports" 
+    :getValue="(study) => study.ecoData?.macroData?.rateOfIntegration"
+  >
+    <template #default="{ value }">
+      <ComparisonDefaultCell :value="value" valueType="percent" />
+    </template>
+  </ComparisonRow>
+
+  <!-- To replace by jobs and net operating profit per actor dropdown -->
   <ComparisonExpandableRow
     :studies="studies" 
     title="Benefit/Cost ratio" 
@@ -22,59 +57,15 @@
       <ComparisonDefaultCell :value="value" valueType="percent" />
     </template>
   </ComparisonExpandableRow>
-  
-  <ComparisonRow 
-    :studies="studies" 
-    title="Share of agricultural GDP" 
-    subtitle="Value chain GDP divided by agricultural GDP" 
-    :getValue="(study) => study.ecoData?.macroData?.valueAddedShareAgriculturalGdp"
-  >
-    <template #default="{ value }">
-      <ComparisonDefaultCell :value="value" valueType="percent" />
-    </template>
-  </ComparisonRow>
-  
-  <ComparisonRow 
-    :studies="studies" 
-    title="Share of national GDP" 
-    subtitle="Value chain GDP divided by national GDP" 
-    :getValue="(study) => study.ecoData?.macroData?.valueAddedShareNationalGdp"
-  >
-    <template #default="{ value }">
-      <ComparisonDefaultCell :value="value" valueType="percent" />
-    </template>
-  </ComparisonRow>
-  
+
   <ComparisonRow 
     :studies="studies" 
     title="Gini Index" 
-    subtitle="-" 
+    subtitle="Ranges from equality (0) to inequality (1)" 
     :getValue="(study) => study.ecoData?.macroData?.giniIndex"
   >
     <template #default="{ value }">
-      <ComparisonDefaultCell :value="value" valueType="percent" />
-    </template>
-  </ComparisonRow>
-  
-  <ComparisonRow 
-    :studies="studies" 
-    title="Rate Of Integration" 
-    subtitle="-" 
-    :getValue="(study) => study.ecoData?.macroData?.rateOfIntegration"
-  >
-    <template #default="{ value }">
-      <ComparisonDefaultCell :value="value" valueType="percent" />
-    </template>
-  </ComparisonRow>
-  
-  <ComparisonRow 
-    :studies="studies" 
-    title="Nominal Protection Coefficient" 
-    subtitle="-" 
-    :getValue="(study) => study.ecoData?.macroData?.nominalProtectionCoefficient"
-  >
-    <template #default="{ value }">
-      <ComparisonDefaultCell :value="value" valueType="percent" />
+      <ComparisonDefaultCell :value="value" valueType="number" />
     </template>
   </ComparisonRow>
 </template>

--- a/src/components/comparison/ComparisonEconomics.vue
+++ b/src/components/comparison/ComparisonEconomics.vue
@@ -29,8 +29,13 @@
     subtitle="Total value added of value chain" 
     :getValue="getTotalAddedValue"
   >
-    <template #default="{ value }">
-      <ComparisonDefaultCell :value="value" valueType="number" />
+    <template #default="{ value, studyData }">
+      <ComparisonDefaultCell
+        :value="value"
+        :studyData="studyData"
+        valueType="amount"
+        currency="USD"
+      />
     </template>
   </ComparisonRow>
 

--- a/src/components/comparison/ComparisonEconomics.vue
+++ b/src/components/comparison/ComparisonEconomics.vue
@@ -34,7 +34,7 @@
         :value="value"
         :studyData="studyData"
         valueType="amount"
-        currency="USD"
+        preferredCurrency="USD"
       />
     </template>
   </ComparisonRow>
@@ -75,7 +75,7 @@
         :value="value"
         valueType="amount"
         :studyData="studyData"
-        currency="USD"
+        preferredCurrency="USD"
       />
     </template>
   </ComparisonExpandableRow>

--- a/src/components/comparison/ComparisonEconomics.vue
+++ b/src/components/comparison/ComparisonEconomics.vue
@@ -48,13 +48,30 @@
   <!-- To replace by jobs and net operating profit per actor dropdown -->
   <ComparisonExpandableRow
     :studies="studies" 
-    title="Benefit/Cost ratio" 
-    subtitle="-" 
-    :getValue="study => study.metrics.eco?.benefitCostRatio.benefitCostRatio"
-    :getSubValues="getBenefitCostRatioByStage"
+    title="Jobs" 
+    subtitle="Total waged employement, excluding family work" 
+    :getValue="getTotalJobs"
+    :getSubValues="getJobsByStage"
   >
     <template #default="{ value }">
-      <ComparisonDefaultCell :value="value" valueType="percent" />
+      <ComparisonDefaultCell :value="value" valueType="number" />
+    </template>
+  </ComparisonExpandableRow>
+
+  <ComparisonExpandableRow
+    :studies="studies" 
+    title="Net operating profit per producer" 
+    subtitle="Average net operating profit per actor at each stage" 
+    :getValue="getNetOperatingProfitPerProducer"
+    :getSubValues="getNetOperatingProfitForOtherStages"
+  >
+    <template #default="{ value, studyData }">
+      <ComparisonDefaultCell
+        :value="value"
+        valueType="amount"
+        :studyData="studyData"
+        currency="USD"
+      />
     </template>
   </ComparisonExpandableRow>
 
@@ -71,6 +88,7 @@
 </template>
 
 <script setup>
+import _ from "lodash";
 import { getTotalAddedValue } from '@utils/economics.js'
 import ComparisonTitle from './ComparisonTitle.vue';
 import ComparisonRow from './ComparisonRow.vue';
@@ -80,18 +98,48 @@ defineProps({
     studies: Array,
 })
 
-function getBenefitCostRatioByStage(studyData) {
-  if (! studyData.metrics.eco) { return {}; }
-  const stagesWithBenefit = studyData.metrics.eco?.benefitCostRatio.stages
-    .filter(stage => stage.netOperatingProfits !== 0);
+function getTotalJobs(studyData) {
+  const jobByStage = getJobsByStage(studyData);
+  if (_.isEmpty(jobByStage)) { return; }
 
-  const benefitCostRatioByStage = {};
-  stagesWithBenefit.forEach(stage => {
-    benefitCostRatioByStage[stage.name] = stage.benefitCostRatio;
-  });
-  return benefitCostRatioByStage;
+  return _.sumBy(Object.values(jobByStage));
+}
+function getJobsByStage(studyData) {
+  if (! studyData.metrics.eco?.employment?.employmentByStage) { return {}; }
+
+  const employmentByStage = studyData.metrics.eco.employment?.employmentByStage;
+  if (! employmentByStage) { return {}; }
+
+  const jobsByStage = {};
+  Object.keys(employmentByStage).forEach(stage => {
+    if (! employmentByStage[stage].total) { return; }
+    jobsByStage[stage] = employmentByStage[stage].total;
+  })
+  return jobsByStage
 }
 
+function getNetOperatingProfitPerProducer(studyData) {
+  if (! studyData.metrics.eco?.netOperatingProfitPerActor) { return null; }
+
+  return studyData.metrics.eco.netOperatingProfitPerActor?.Producers?.profitPerActor;
+}
+
+function getNetOperatingProfitForOtherStages(studyData) {
+  if (! studyData.metrics.eco?.netOperatingProfitPerActor) { return {}; }
+
+  const netOperatingProfitForOtherStages = {};
+  const nonProducerStages = Object.keys(studyData.metrics.eco?.netOperatingProfitPerActor).filter(stageName => stageName !== "Producers");
+  nonProducerStages.forEach(stageName => {
+    netOperatingProfitForOtherStages[buildPerStageName(stageName)] = studyData.metrics.eco.netOperatingProfitPerActor?.[stageName]?.profitPerActor;
+  })
+  return netOperatingProfitForOtherStages;
+}
+
+function buildPerStageName(stageName) {
+  const lowercaseStageName = _.lowerCase(stageName);
+  const singularStageName = lowercaseStageName.replace(/s$/, "");
+  return `Per ${singularStageName}`;
+}
 </script>
 
 <style lang="scss">

--- a/src/components/comparison/ComparisonEnvironment.vue
+++ b/src/components/comparison/ComparisonEnvironment.vue
@@ -1,27 +1,37 @@
 <template>
   <template v-if="impacts.length > 0">
     <ComparisonTitle title="Environmental Indicators" :studies="studies" />
-    <ComparisonRow
-      v-for="impact in impacts"
-      :key="`impact_${impact.name}`"
+    <ComparisonExpandableRow
       :studies="studies"
-      :title="impact.name"
-      :subtitle="`in ${getUnitImpact(impact.name)}`"
-      :getValue="(study) => getImpactValue(impact, study)"
+      title="Total impact per year"
+      subtitle="Value chain total impact (in pt)"
+      :getValue="(study) => getTotalImpacts(study, true)"
+      :getSubValues="(study) => getValuesByImpact(study, true)"
     >
       <template #default="{ value }">
         <ComparisonDefaultCell :value="value" valueType="number" />
       </template>
-    </ComparisonRow>
+    </ComparisonExpandableRow>
+    <ComparisonExpandableRow
+      :studies="studies"
+      title="Impact per functional unit"
+      subtitle="Value chain total impact / volume"
+      :getValue="(study) => getTotalImpacts(study, false)"
+      :getSubValues="(study) => getValuesByImpact(study, false)"
+    >
+      <template #default="{ value }">
+        <ComparisonDefaultCell :value="value" valueType="number" />
+      </template>
+    </ComparisonExpandableRow>
   </template>
 </template>
 
 <script setup>
-
+import _ from "lodash";
 import { ACVImpacts } from '@utils/misc.js'
 import { computed } from 'vue';
 import ComparisonTitle from './ComparisonTitle.vue';
-import ComparisonRow from './ComparisonRow.vue';
+import ComparisonExpandableRow from './ComparisonExpandableRow.vue';
 import ComparisonDefaultCell from './ComparisonDefaultCell.vue';
 const props = defineProps({
     studies: Array,
@@ -34,24 +44,42 @@ const availableImpacts = computed(() => props.studies.reduce((arr, study) => arr
 
 const impacts = computed(() => ACVImpacts.filter(item => availableImpacts.value.map(availableImpact => availableImpact.name).includes(item.name)))
 
-const getUnitImpact = (impactName) => availableImpacts.value.find(impact => impact.name === impactName).unit
+function getTotalImpacts(study, sumTotalPerYear = false) {
+  const valuesByImpact = getValuesByImpact(study, sumTotalPerYear);
+  if (_.isEmpty(valuesByImpact)) { return null; }
 
-const getImpactValue = (impact, study) => {
-    if (!study.acvData) {
-        return null;
-    }
-    const valueChains = study.acvData.valuechains
-    let total = 0
-    for (const { name, volume} of valueChains) {
-        const totalChainPerT = study.acvData.impacts
-            .filter(i => i.name === impact.name)
-            .filter(i => i.unit === 'Pt')
-            .reduce((arr, item) => arr.concat(item.values), [])
-            .filter(val => val.valuechain_name === name)
-            .map(val => val.value * volume).reduce((s, item) => s + item, 0)
-        total += totalChainPerT
-    }
-    return total
+  return _.sumBy(Object.values(valuesByImpact));
+}
+
+function getValuesByImpact(study, sumTotalPerYear = false) {
+  const valuesByImpact = {};
+  impacts.value.forEach((impact) => {
+    const impactValue = getImpactValue(impact, study, sumTotalPerYear);
+    if (_.isNull(impactValue)) { return; }
+
+    valuesByImpact[impact.name] = impactValue;
+  });
+  return valuesByImpact;
+}
+
+function getImpactValue(impact, study, sumTotalPerYear = false) {
+  if (!study.acvData) {
+      return null;
+  }
+  const valueChains = study.acvData.valuechains
+  let totalPerYear = 0;
+  let totalVolume = 0;
+  for (const { name, volume} of valueChains) {
+    const totalChainPerYear = study.acvData.impacts
+      .filter(i => i.name === impact.name)
+      .filter(i => i.unit === 'Pt')
+      .reduce((arr, item) => arr.concat(item.values), [])
+      .filter(val => val.valuechain_name === name)
+      .map(val => val.value * volume).reduce((s, item) => s + item, 0)
+    totalVolume += volume;
+    totalPerYear += totalChainPerYear
+  }
+  return sumTotalPerYear ? totalPerYear : (totalPerYear / totalVolume)
 }
 
 </script>

--- a/src/components/comparison/ComparisonEnvironment.vue
+++ b/src/components/comparison/ComparisonEnvironment.vue
@@ -38,7 +38,7 @@ const getUnitImpact = (impactName) => availableImpacts.value.find(impact => impa
 
 const getImpactValue = (impact, study) => {
     if (!study.acvData) {
-        return 0
+        return null;
     }
     const valueChains = study.acvData.valuechains
     let total = 0

--- a/src/components/comparison/ComparisonEnvironment.vue
+++ b/src/components/comparison/ComparisonEnvironment.vue
@@ -29,7 +29,7 @@ const props = defineProps({
 
 const availableImpacts = computed(() => props.studies.reduce((arr, study) => arr.concat(study.acvData?.impacts), [])
 .filter(item => !!item)
-.filter(item => item.unit !== 'Pt')
+.filter(item => item.unit === 'Pt')
 )
 
 const impacts = computed(() => ACVImpacts.filter(item => availableImpacts.value.map(availableImpact => availableImpact.name).includes(item.name)))
@@ -45,7 +45,7 @@ const getImpactValue = (impact, study) => {
     for (const { name, volume} of valueChains) {
         const totalChainPerT = study.acvData.impacts
             .filter(i => i.name === impact.name)
-            .filter(i => i.unit !== 'Pt')
+            .filter(i => i.unit === 'Pt')
             .reduce((arr, item) => arr.concat(item.values), [])
             .filter(val => val.valuechain_name === name)
             .map(val => val.value * volume).reduce((s, item) => s + item, 0)

--- a/src/components/comparison/ComparisonEnvironment.vue
+++ b/src/components/comparison/ComparisonEnvironment.vue
@@ -10,7 +10,7 @@
       :getValue="(study) => getImpactValue(impact, study)"
     >
       <template #default="{ value }">
-        <ComparisonDefaultCell :value="value" valueType="number" reverseColors />
+        <ComparisonDefaultCell :value="value" valueType="number" />
       </template>
     </ComparisonRow>
   </template>

--- a/src/components/comparison/ComparisonExpandableRow.vue
+++ b/src/components/comparison/ComparisonExpandableRow.vue
@@ -9,8 +9,8 @@
     :expanded="expanded"
     @toggle-expand="toggleExpand()"
   >
-    <template #default="{ value }">
-      <slot :value="value" />
+    <template #default="{ value, studyData }">
+      <slot :value="value" :studyData="studyData" />
     </template>
   </ComparisonRow>
   <ComparisonRow
@@ -22,8 +22,8 @@
     :title="subKey"
     :getValue="study => getSubValues(study)[subKey]"
   >
-    <template #default="{ value }">
-      <slot :value="value" />
+    <template #default="{ value, studyData }">
+      <slot :value="value" :studyData="studyData" />
     </template>
   </ComparisonRow>
 </template>

--- a/src/components/comparison/ComparisonRow.vue
+++ b/src/components/comparison/ComparisonRow.vue
@@ -8,7 +8,7 @@
       <div v-if="subtitle" class="definition">{{ subtitle }}</div>
     </td>
     <td v-for="(study, index) in studies" :key="`value_added__${study.id}`">
-      <slot :value="values[index]" />
+      <slot :value="values[index]" :studyData="study" />
     </td>
     <td />
   </tr>

--- a/src/utils/data/metrics/eco/employment.js
+++ b/src/utils/data/metrics/eco/employment.js
@@ -43,6 +43,7 @@ function sumActorsEmploymentByType(actors) {
     unskilledMale: sumActorsEmployments(actors, ["unskilledMale"]),
     skilledFemale: sumActorsEmployments(actors, ["skilledFemale"]),
     skilledMale: sumActorsEmployments(actors, ["skilledMale"]),
+    total: sumActorsEmployments(actors, ALL_EMPLOYMENT_TYPES),
     employmentActorDistribution: getEmploymentActorDistribution(actors),
   }
 }

--- a/src/utils/data/metrics/eco/netOperatingProfitPerActor.js
+++ b/src/utils/data/metrics/eco/netOperatingProfitPerActor.js
@@ -1,0 +1,29 @@
+import _ from "lodash";
+
+export function buildNetOperatingProfitPerActor(ecoData) {
+  const actors = ecoData.actors;
+  if (! actors) { return null; }
+  const stages = _.uniq(actors.map(actor => actor.stage));
+
+  const netOperatingProfitPerActorByStage = {};
+
+  stages.forEach(stageName => {
+    const stageActors = actors.filter(actor => actor.stage === stageName)
+    const subTotalOperatingProfit = _.sumBy(stageActors, actor => actor.netOperatingProfit || 0);
+    const subTotalNumberOfActors = _.sumBy(stageActors, actor => actor.numberOfActors || 0);
+    const partialStageActors = stageActors.map(actor => ({
+      name: actor.name,
+      netOperatingProfit: actor.netOperatingProfit,
+      numberOfActors: actor.numberOfActors,
+    }));
+
+    if (subTotalOperatingProfit !== 0 && subTotalNumberOfActors !== 0) {
+      netOperatingProfitPerActorByStage[stageName] = {
+        profitPerActor: subTotalOperatingProfit / subTotalNumberOfActors,
+        stageActors: partialStageActors
+      }
+    }
+  });
+
+  return netOperatingProfitPerActorByStage;
+}

--- a/src/utils/data/metrics/index.js
+++ b/src/utils/data/metrics/index.js
@@ -1,5 +1,6 @@
 import { buildBenefitCostRatioData } from "./eco/benefitCostRatio.js";
 import { buildGlobalEmploymentData } from "./eco/employment.js";
+import { buildNetOperatingProfitPerActor } from "./eco/netOperatingProfitPerActor.js";
 
 export function computeMetrics(studyData) {
   return {
@@ -12,6 +13,7 @@ function buildEcoMetrics(studyData) {
 
   return {
     benefitCostRatio: buildBenefitCostRatioData(studyData.ecoData),
-    employment: buildGlobalEmploymentData(studyData.ecoData)
+    employment: buildGlobalEmploymentData(studyData.ecoData),
+    netOperatingProfitPerActor: buildNetOperatingProfitPerActor(studyData.ecoData)
   };
 }


### PR DESCRIPTION
Resolves #110

## Contexte

Après les retours utilisateurs, on a remarqu" que la page de comparaison pouvait etre mieux présentée

- Les couleurs vert/rouge ne permettent pas de comparaison
- Les indicateurs économiques ne sont pas les bons à présenter pour avoir le plus d'impact
- Pour comparer l'acv, il faut utiliser des Pt, et pas les untiés spécifiques

## Changements

cf #110 pour la spec. Quelques textes ont été communiqués sur Teams par Marion

- Refacto (3 commits): Passer le netOperatingProfitPerActor dans les metrics afin d'y acceder dans la page de comparaison
- :one: Passer toutes les cellules de comparaison (outre le social) en bleu
- :two: Refondre les indicateurs économiques
  - On réordonne / supprime l'existant (On change l'unité du gini index également)
  - On ajoute 2 dropdown (jobs et net operating profit per actor). Note: Pour le net operating profit per actor, le rang "Parent" n'est pas une somme ou une moyenne, mais le net operating profit des Producers
  - On s'assure que les cellules qui représentent de l'argent affichent des monnaies (dollars convertis)
- :three: On change comment on compare l'acv
  - On met tout en "Pt" (ce qui fait disparaitre Global warming", c'est normal
  - On fait 2 dropdown: Un par unité fonctionnelle et un par 'total impact per year'.