### PR TITLE
feat(124): Some tweaks for comparison page + bring up Sankey

### DIFF
--- a/src/components/StudyOverview.vue
+++ b/src/components/StudyOverview.vue
@@ -8,6 +8,10 @@
       <StagesDescription :stagesDescription="studyData.ecoData.stages" />
     </section>
 
+    <section v-if="studyData && studyData.ecoData">
+      <Sankey :studyData="studyData" />
+    </section>
+
     <section v-if="studyData" class="explore">
       <h2>Explore up to 4 dimensions of the value chain</h2>
       <div
@@ -53,9 +57,6 @@
           Learn more about the value chain’s damages to Human Health, Ecosystem Quality, Natural Resources and Climate Change
         </p>
       </div>
-    </section>
-    <section v-if="studyData && studyData.ecoData">
-      <Sankey :studyData="studyData" />
     </section>
     <PdfSection v-if="studyUrls.briefPdf" :studyBriefUrl="studyUrls.briefPdf" />
   </article>

--- a/src/components/comparison/ComparisonRow.vue
+++ b/src/components/comparison/ComparisonRow.vue
@@ -32,7 +32,7 @@ const values = computed(() => props.studies.map(study => props.getValue(study)))
 
 <style scoped lang="scss">
   .row-header {
-    min-width: 250px;
+    min-width: 278px;
     min-height: 50px;
     padding-right: 20px;
     display: flex;

--- a/src/components/comparison/ComparisonTitle.vue
+++ b/src/components/comparison/ComparisonTitle.vue
@@ -20,6 +20,6 @@ defineProps({
 
 <style lang="scss">
   .comparison-title {
-    @apply uppercase text-[#8A8A8A] font-bold text-sm pb-4;
+    @apply uppercase text-[#8A8A8A] font-bold pb-4;
   }
 </style>


### PR DESCRIPTION
Resolves: #124 

## Changements

- Déplacement du Sankey
- Retrait de la taille de police spécifique pour les titres des comparaisons (ex `Macro economic indicators`)

## Note

Le bout de la spec "padding" est en fait un problème de zoom que j'avais vu chez Léa dans la page de comparaison, j'ai noté ça dans la tache "petits écrans": https://www.notion.so/le-basic/S-adapter-aux-petits-crans-1056afc9ad64806aa235c5d6fccda172