### PR TITLE
feat(120): Better display the Share of farm price table

### DIFF
--- a/src/components/study/inclusiveness/ShareOfFarmPrice.vue
+++ b/src/components/study/inclusiveness/ShareOfFarmPrice.vue
@@ -34,22 +34,14 @@ const columns = [{
     field: "label",
     sortable: true,
   }, {
-    label: "Farm product",
-    field: "farmProduct",
-    sortable: true,
-  }, {
     label: "Farm gate price",
     field: "farmPrice",
-    display: (item) => `${prettyAmount.value(convertAmount.value(item.farmPrice))} per kg`,
-    sortable: true,
-  }, {
-    label: "End products",
-    field: "endProducts",
+    display: (item) => formatProductPriceCell(item.farmProduct, item.farmPrice),
     sortable: true,
   }, {
     label: "End products unit value",
     field: "endPrice",
-    display: (item) => `${prettyAmount.value(convertAmount.value(item.endPrice))} per kg`,
+    display: (item) => formatProductPriceCell(item.endProducts, item.endPrice),
     sortable: true,
   }, {
     label: "Farm value part",
@@ -58,6 +50,14 @@ const columns = [{
     sortable: true,
   }
 ]
+
+function formatProductPriceCell(productName, productPrice) {
+  const pricePrettyAmount = prettyAmount.value(convertAmount.value(productPrice))
+  return `
+    <b>${productName}</b><br>
+    ${pricePrettyAmount} per kg
+  `;
+}
 </script>
 
 <style>


### PR DESCRIPTION
Resolves #120

## Changements

On affiche les produits dans la même cellule que le prix dans "Share of Farm price"

| Avant | Après |
| - | - | 
| ![image](https://github.com/user-attachments/assets/936da5a4-99df-4f5b-a494-b319dfed4c87) | ![image](https://github.com/user-attachments/assets/9b523edc-1304-4037-b15c-125e4e3e0b2c) | 