### PR TITLE
feat(118): Separate Browse and compare sections on the home page

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -50,6 +50,11 @@
         </p>
       </section>
       <section>
+        <h2><strong>Compare study results</strong></h2>
+        <p class="mb-4">Draw comparisons between key indicators presented in VCA4D studies : economic growth, inclusiveness, social impacts and environmental indicators.</p>
+        <RouterLink class="button" :to="{ name: 'comparison' }">Compare studies</RouterLink>
+      </section>
+      <section>
         <h2><strong>Browse studies</strong></h2>
         <div class="filter-section">
           <p>Filter the studies on this page based on the topics addressed.</p>
@@ -61,9 +66,6 @@
           <div>
             <div>
               Number of studies: {{ filteredStudies.length }}
-            </div>
-            <div>
-              You can also <RouterLink class="link" :to="{ name: 'comparison' }">compare studies</RouterLink> based on key indicators
             </div>
           </div>
         </div>
@@ -203,6 +205,21 @@ section.banner {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+
+.button {
+  color:white;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  background-color: #3F83F8;
+  border-radius: 0.25rem;
+  right: 0px;
+  width: 200px;
+
+  &:hover {
+    background-color: #1A56DB;
+  }
 }
 
 .link {


### PR DESCRIPTION
Resolves #118 

| Avant | Après |
| - | - | 
| ![image](https://github.com/user-attachments/assets/dd4027fe-985a-41c4-b48f-ce203e4b95f7) | ![image](https://github.com/user-attachments/assets/2fac97e9-abef-40b3-a6c0-4d2a69155cde) |

Notes:

J'ai copié collé le css du bouton de la page de comparaison, pour ne pas s'embeter à factoriser les deux boutons (un qui va vers un lien, un autre qui déclenche une action).