### PR TITLE
feat(122): Add banner to warn about local study status

### DIFF
--- a/src/components/study/LocalStudyBanner.vue
+++ b/src/components/study/LocalStudyBanner.vue
@@ -4,13 +4,13 @@
       ⚠️ <b>NOT PUBLISHED : </b>&nbsp;
       This study hasn’t been published to the web and is only available on your device. 
       Once ready, publish it by contacting BASIC or 
-      &nbsp;<a class="remove-action">click here to remove it from your device</a>
+      &nbsp;<a class="remove-action" @click="emits('click-clear')">click here to remove it from your device</a>
     </div>
   </Teleport>
 </template>
 
 <script setup>
-
+const emits = defineEmits(["click-clear"])
 </script>
 
 <style scoped lang="scss">

--- a/src/components/study/LocalStudyBanner.vue
+++ b/src/components/study/LocalStudyBanner.vue
@@ -1,0 +1,37 @@
+<template>
+  <Teleport to="body">
+    <div class="local-study-banner">
+      ⚠️ <b>NOT PUBLISHED : </b>&nbsp;
+      This study hasn’t been published to the web and is only available on your device. 
+      Once ready, publish it by contacting BASIC or 
+      &nbsp;<a class="remove-action">click here to remove it from your device</a>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped lang="scss">
+.local-study-banner {
+  background-color: #FFCE0B;
+
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  position: fixed;
+  top: 0;
+
+  .remove-action {
+    cursor: pointer;
+    color: #3F83F8;
+
+    &:hover {
+      color: #1C64F2;
+    }
+  }
+}
+</style>

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -65,3 +65,8 @@ export const ACVImpacts = [
         helpBoxText: "LCA aims at capturing depletion of resources by focusing on the level of non-renewable stocks and the rate of use of renewable resources to their replacement. The indicator is the increased cost to continue extractions which is expressed by US $."
     }
 ]
+
+export function clearLocalStorage() {
+  localStorage.removeItem('localWorkbook')
+  localStorage.removeItem('localStudyData')
+}

--- a/src/views/Import.vue
+++ b/src/views/Import.vue
@@ -1,4 +1,5 @@
 <template>
+  <LocalStudyBanner v-if="isStudyObjectNotEmpty" />
   <Skeleton :skipFooter="true">
     <div class="corps-page-import">
       <h1>Add a study to the VCA4D website</h1>
@@ -33,6 +34,7 @@ import * as XLSX from 'xlsx'
 import Skeleton from '@components/Skeleton.vue'
 import SaveOnGithubStep from '@components/import/SaveOnGithubStep.vue'
 import CheckImportedDataStep from '@components/import/CheckImportedDataStep.vue'
+import LocalStudyBanner from '@components/study/LocalStudyBanner.vue'
 
 import { getAllJsonData } from '@utils/data';
 import { processUploadedExcelFile } from '@utils/import/generic.js'

--- a/src/views/Import.vue
+++ b/src/views/Import.vue
@@ -1,5 +1,5 @@
 <template>
-  <LocalStudyBanner v-if="isStudyObjectNotEmpty" />
+  <LocalStudyBanner v-if="isStudyObjectNotEmpty" @click-clear="clearData" />
   <Skeleton :skipFooter="true">
     <div class="corps-page-import">
       <h1>Add a study to the VCA4D website</h1>
@@ -36,15 +36,15 @@ import SaveOnGithubStep from '@components/import/SaveOnGithubStep.vue'
 import CheckImportedDataStep from '@components/import/CheckImportedDataStep.vue'
 import LocalStudyBanner from '@components/study/LocalStudyBanner.vue'
 
+import { clearLocalStorage } from '@utils/misc';
 import { getAllJsonData } from '@utils/data';
 import { processUploadedExcelFile } from '@utils/import/generic.js'
 
 const workbook = ref(null)
 
 const clearData = () => {
-    localStorage.removeItem('localWorkbook')
-    localStorage.removeItem('localStudyData')
-    workbook.value = null
+  clearLocalStorage()
+  workbook.value = null
 }
 
 const knownProducts = ref([])

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -1,4 +1,5 @@
 <template>
+  <LocalStudyBanner v-if="route.query.id === LOCAL_STORAGE_ID" />
   <Skeleton>
     <div class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 max-w-[90%]">
       <header>
@@ -53,8 +54,9 @@ import StudySocialSustainability from '@components/StudySocialSustainability.vue
 import StudyHeader from '@components/study/StudyHeader.vue'
 import StudyMenu from '@components/study/StudyMenu.vue'
 import { getStudyData } from '@utils/data'
-import { getStudyUploadUrls } from '../utils/data'
+import { getStudyUploadUrls, LOCAL_STORAGE_ID } from '../utils/data'
 import { isCurrencySupported } from '@utils/currency.js'
+import LocalStudyBanner from '@components/study/LocalStudyBanner.vue'
 
 const route = useRoute();
 const router = useRouter()

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -1,5 +1,5 @@
 <template>
-  <LocalStudyBanner v-if="route.query.id === LOCAL_STORAGE_ID" />
+  <LocalStudyBanner v-if="route.query.id === LOCAL_STORAGE_ID" @click-clear="removeLocalStudy" />
   <Skeleton>
     <div class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 max-w-[90%]">
       <header>
@@ -57,6 +57,7 @@ import { getStudyData } from '@utils/data'
 import { getStudyUploadUrls, LOCAL_STORAGE_ID } from '../utils/data'
 import { isCurrencySupported } from '@utils/currency.js'
 import LocalStudyBanner from '@components/study/LocalStudyBanner.vue'
+import { clearLocalStorage } from '@utils/misc'
 
 const route = useRoute();
 const router = useRouter()
@@ -162,6 +163,11 @@ function setupCurrency() {
 const isDataLoaded = computed(() => {
   return !! studyData.value && !! studyUrls.value;
 });
+
+function removeLocalStudy() {
+  clearLocalStorage();
+  router.replace({ name: "home" });
+}
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
Resolves #122 

## Contexte

On veut attirer l'attention des clients qui importent des données que ces données ne sont présentes qu'en local
On affiche donc la banière suivante

- Sur la page d'import (quand on a un import fait)
- Sur les pages de l'étude importée

![image](https://github.com/user-attachments/assets/e9f1fc3e-bf90-479e-9ba9-9f7783221144)

## Changements

- Création de la bannière + affichage dans les bonnes pages
- Emission d'un event pour supprimer l'étude en question dans les 2 composants parents