### PR TITLE
fix(128): adapt several pages to small screens

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -22,6 +22,7 @@ const emits = defineEmits(["close"]);
 
 </script>
 
+
 <style scoped lang="scss">
 .modal-overlay {
   position: fixed;
@@ -39,6 +40,7 @@ const emits = defineEmits(["close"]);
   .modal {
     min-width: 300px;
     min-height: 100px;
+    max-height: 100vh;
     padding: 20px 50px;
     border-radius: 12px;
     background-color: white;

--- a/src/components/Skeleton.vue
+++ b/src/components/Skeleton.vue
@@ -30,7 +30,7 @@
 
   <footer v-if="!skipFooter">
     <ul>
-      <li><a target="_blank" class="hover:underline" href="https://github.com/leonarf/VCA4D">Code source sur Github</a></li>
+      <li><a target="_blank" class="hover:underline" href="https://github.com/leonarf/VCA4D">Source code on Github</a></li>
       <li>
         <RouterLink class="hover:underline" to="/admin-import">Import a study</RouterLink>
       </li>

--- a/src/components/comparison/StudiesListTable.vue
+++ b/src/components/comparison/StudiesListTable.vue
@@ -3,7 +3,7 @@
     class="table"
     selectable
     :selectedIds="newSelectedStudies"
-    :maxHeight="500"
+    :maxHeight="400"
     :pageSize="50"
     :rows="studies"
     :columns="columns"

--- a/src/components/home/ByCategory.vue
+++ b/src/components/home/ByCategory.vue
@@ -25,7 +25,6 @@
             <Dropdown
               :shown="openedProduct === item.product"
               :triggers="[]"
-              :distance="-30"
               :overflowPadding="20"
               placement="bottom"
             >
@@ -50,7 +49,7 @@
                 <SubCardsList
                   v-if="openedProduct === item.product" 
                   :link="{ name: 'comparison', query: { studies: getStudyListQueryString(item.studies.map(study => study.id)) } }"
-                  :linkTitle="`Compare all ${item.product} studies`"
+                  :linkTitle="`Compare all ${getProduct(item.product).prettyName.toLowerCase()} studies`"
                 >
                   <Card
                     v-for="study in item.studies"

--- a/src/components/home/ByCategory.vue
+++ b/src/components/home/ByCategory.vue
@@ -22,16 +22,31 @@
             </Card>
           </template>
           <template v-else>
-            <Card
-              :isLocal="false"
-              :isOpen="openedProduct === item.product"
-              :title="getProduct(item.product).prettyName"
-              @click.stop="openedProduct === item.product ? openedProduct = null : openedProduct = item.product"
+            <Dropdown
+              :shown="openedProduct === item.product"
+              :triggers="[]"
+              :distance="-30"
+              :overflowPadding="20"
+              placement="bottom"
             >
-              <template #logo>
-                <LogoProductLarge :productName="item.product" />
-              </template>
-              <template #footer>
+              <Card
+                :isLocal="false"
+                :isOpen="openedProduct === item.product"
+                :title="getProduct(item.product).prettyName"
+                @click.stop="openedProduct === item.product ? openedProduct = null : openedProduct = item.product"
+              >
+                <template #logo>
+                  <LogoProductLarge :productName="item.product" />
+                </template>
+                <template #footer>
+                  <CardFooter text="countries">
+                    <template #logo>
+                      <NumberBadge :value="item.studies.length" />
+                    </template>
+                  </CardFooter>
+                </template>
+              </Card>
+              <template #popper>
                 <SubCardsList
                   v-if="openedProduct === item.product" 
                   :link="{ name: 'comparison', query: { studies: getStudyListQueryString(item.studies.map(study => study.id)) } }"
@@ -49,13 +64,8 @@
                     </template>
                   </Card>
                 </SubCardsList>
-                <CardFooter v-else text="countries">
-                  <template #logo>
-                    <NumberBadge :value="item.studies.length" />
-                  </template>
-                </CardFooter>
               </template>
-            </Card>
+            </Dropdown>
           </template>
         </li>
       </CardList>
@@ -77,6 +87,7 @@ import CardFooter from './CardFooter.vue';
 import NumberBadge from './NumberBadge.vue';
 import Card from './Card.vue';
 import SubCardsList from './SubCardsList.vue'
+import { Dropdown } from 'floating-vue';
 
 const props = defineProps({
     studies: Array,

--- a/src/components/home/ByContinent.vue
+++ b/src/components/home/ByContinent.vue
@@ -24,7 +24,6 @@
           <Dropdown
             :shown="openedCountry === item.country"
             :triggers="[]"
-            :distance="-30"
             :overflowPadding="20"
             placement="bottom"
           >
@@ -49,7 +48,7 @@
               <SubCardsList
                 v-if="openedCountry === item.country"
                 :link="{ name: 'comparison', query: { studies: getStudyListQueryString(item.studies.map(study => study.id)) } }"
-                :linkTitle="`Compare all ${item.country} studies`"
+                :linkTitle="`Compare all ${getCountry(item.country).prettyName} studies`"
               >
                 <Card
                   v-for="study in item.studies"

--- a/src/components/home/ByContinent.vue
+++ b/src/components/home/ByContinent.vue
@@ -21,16 +21,31 @@
           </Card>
         </template>
         <template v-else>
-          <Card
-            :isLocal="false"
-            :isOpen="openedCountry === item.country"
-            :title="getCountry(item.country).prettyName"
-            @click.stop="openedCountry === item.country ? openedCountry = null : openedCountry = item.country"
+          <Dropdown
+            :shown="openedCountry === item.country"
+            :triggers="[]"
+            :distance="-30"
+            :overflowPadding="20"
+            placement="bottom"
           >
-            <template #logo>
-              <LogoCountryLarge :isoCode="getCountry(item.country).iso || 'gr'" />
-            </template>
-            <template #footer>
+            <Card
+              :isLocal="false"
+              :isOpen="openedCountry === item.country"
+              :title="getCountry(item.country).prettyName"
+              @click.stop="openedCountry === item.country ? openedCountry = null : openedCountry = item.country"
+            >
+              <template #logo>
+                <LogoCountryLarge :isoCode="getCountry(item.country).iso || 'gr'" />
+              </template>
+              <template #footer>
+                <CardFooter text="studies">
+                  <template #logo>
+                    <NumberBadge :value="item.studies.length" />
+                  </template>
+                </CardFooter>
+              </template>
+            </Card>
+            <template #popper>
               <SubCardsList
                 v-if="openedCountry === item.country"
                 :link="{ name: 'comparison', query: { studies: getStudyListQueryString(item.studies.map(study => study.id)) } }"
@@ -48,13 +63,8 @@
                   </template>
                 </Card>
               </SubCardsList>
-              <CardFooter v-else text="studies">
-                <template #logo>
-                  <NumberBadge :value="item.studies.length" />
-                </template>
-              </CardFooter>
             </template>
-          </Card> 
+          </Dropdown>
         </template>
       </li>   
     </CardList>
@@ -75,6 +85,8 @@ import CardFooter from './CardFooter.vue';
 import NumberBadge from './NumberBadge.vue';
 import Card from './Card.vue';
 import SubCardsList from './SubCardsList.vue';
+import { Dropdown } from 'floating-vue';
+
 const props = defineProps({
     continent: String,
     studies: Array,

--- a/src/components/home/SubCardsList.vue
+++ b/src/components/home/SubCardsList.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="absolute top-[120px] bg-[#F0F0F0] p-4 rounded-lg text-white z-50 sub-cards-list">
-    <div class="flex flex-row gap-x-4">
+  <div class="p-4 rounded-lg text-white z-50 sub-cards-list">
+    <div class="studies-list">
       <slot />
     </div>
     <div v-if="link" class="text-center w-full">
@@ -27,7 +27,10 @@ defineProps({
 </script>
 
 <style scoped lang="scss">
-.sub-cards-list{
-    box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+.studies-list {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 </style>

--- a/src/components/study/LocalStudyBanner.vue
+++ b/src/components/study/LocalStudyBanner.vue
@@ -1,10 +1,14 @@
 <template>
   <Teleport to="body">
     <div class="local-study-banner">
-      ⚠️ <b>NOT PUBLISHED : </b>&nbsp;
-      This study hasn’t been published to the web and is only available on your device. 
-      Once ready, publish it by contacting BASIC or 
-      &nbsp;<a class="remove-action" @click="emits('click-clear')">click here to remove it from your device</a>
+      <div class="warning">
+        ⚠️ <b>NOT PUBLISHED : </b>&nbsp;
+      </div>
+      <div>
+        This study hasn’t been published to the web and is only available on your device. 
+        Once ready, publish it by contacting BASIC or 
+        &nbsp;<a class="remove-action" @click="emits('click-clear')">click here to remove it from your device</a>
+      </div>
     </div>
   </Teleport>
 </template>
@@ -17,13 +21,18 @@ const emits = defineEmits(["click-clear"])
 .local-study-banner {
   background-color: #FFCE0B;
 
-  height: 50px;
+  min-height: 50px;
+  padding: 12px;
   display: flex;
-  align-items: center;
+  align-items: top;
   justify-content: center;
   width: 100%;
   position: fixed;
   top: 0;
+
+  > .warning {
+    flex-shrink: 0;
+  }
 
   .remove-action {
     cursor: pointer;

--- a/src/components/study/StudyHeader.vue
+++ b/src/components/study/StudyHeader.vue
@@ -42,7 +42,7 @@
       <div class="header-subtitle">Reference year</div>
     </div>
     <div class="download-title">
-      <Dropdown :distance="25" :overflowPadding="20">
+      <Dropdown :distance="25" :overflowPadding="20" placement="bottom">
         <div class="download-button">
           <Svg :svg="DowloadLogo" />
         </div>

--- a/src/style/tooltips-override.scss
+++ b/src/style/tooltips-override.scss
@@ -17,4 +17,8 @@
     border: none !important;
     box-shadow: 4px 4px 17px 0px #00000040 !important;
   }
+
+  .v-popper__arrow-outer {
+    border: none !important;
+  }
 }

--- a/src/views/Comparison.vue
+++ b/src/views/Comparison.vue
@@ -8,7 +8,7 @@
           @select-studies="selectStudies($event)"
         />
       </div>
-      <div v-else-if="loading === false" class="mx-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 no-study">
+      <div v-else-if="loading === false" class="mx-4 mb-4 sm:mx-8 md:mx-12 lg:mx-40 xl:mx-48 no-study">
         No study is selected
         <AddStudiesButton
           class="mt-4"


### PR DESCRIPTION
Resolves #128

## Contexte

Lors des interviews utilisatrices, on a remarqué que certaisn écrans étaient petits / les navigateurs étaient zoomés par défaut (150%)

Cela demande quelques ajustements pour que le contenu s'affiche correctement

## Changements

- :one: Limiter la hauteur de la modale de la page de comparaison pour que le bouton soit bien visible
- :two: Utilisation du nouveau dropdown floating-vue pour les sous-cartes de la page d'études (quand on a plusieurs études sur un meme pays/produit). 
- :three: Adaptation responsive de la bannière de #122 
- :four: Ajout d'une marge minimum en bas du rectange gris qui dit "Pas d'études selectionnée" en page de comparaison (100% cosmetique)