### PR TITLE
feat: Change comparion page default cells

### DIFF
--- a/src/components/StudiesComparison.vue
+++ b/src/components/StudiesComparison.vue
@@ -41,9 +41,18 @@ const emit = defineEmits(["select-studies"]);
         min-width: 20%;
     }
 
+    tr td:not(:first-child):not(:last-child):not(:nth-child(2)) {
+      .default-comparison-cell {
+        border-left: none;
+      }
+    }
     tr td:not(:first-child):not(:last-child):not(:nth-last-child(2)) {
       @apply border-r-2;
       border-right-color: #D1D5DB;
+
+      .default-comparison-cell {
+        border-right: none;
+      }
     }
 
     tr td:first-child > * {

--- a/src/components/comparison/ComparisonDefaultCell.vue
+++ b/src/components/comparison/ComparisonDefaultCell.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="default-comparison-cell" :class="valueClass">
+  <div class="default-comparison-cell" :class="[valueClass, { 'light': lightVersion }]">
     {{ formatedValue }}
   </div>
 </template>
@@ -16,7 +16,8 @@ const props = defineProps({
     valueType: {
       type: String,
       validator: (valueType) => ["amount", "percent", "number"].includes(valueType)
-    }
+    },
+    lightVersion: Boolean
 })
 
 const valueClass = computed(() => {
@@ -56,10 +57,23 @@ const formatedValue = computed(() => {
 </script>
 
 <style scoped lang="scss">
-    .gray {
-      @apply bg-gray-300 text-gray-500
+.default-comparison-cell {
+  &.gray {
+    background-color: #D1D5DB;
+    color: #6B7280;
+    
+    &.light {
+      background-color: #D1D5DB20;
+      border: #D1D5DB solid 2px;
     }
-    .blue {
-        background-color: #A4CAFE;
+  }
+  &.blue {
+    background-color: #A4CAFE;
+
+    &.light {
+      border: #A4CAFE solid 2px;
+      background-color: #A4CAFE20;
     }
+  }
+}
 </style>

--- a/src/components/comparison/ComparisonEconomics.vue
+++ b/src/components/comparison/ComparisonEconomics.vue
@@ -58,8 +58,8 @@
     :getValue="getTotalJobs"
     :getSubValues="getJobsByStage"
   >
-    <template #default="{ value }">
-      <ComparisonDefaultCell :value="value" valueType="number" />
+    <template #default="{ value, isSubRow }">
+      <ComparisonDefaultCell :value="value" :lightVersion="isSubRow" valueType="number" />
     </template>
   </ComparisonExpandableRow>
 
@@ -70,12 +70,13 @@
     :getValue="getNetOperatingProfitPerProducer"
     :getSubValues="getNetOperatingProfitForOtherStages"
   >
-    <template #default="{ value, studyData }">
+    <template #default="{ value, studyData, isSubRow }">
       <ComparisonDefaultCell
         :value="value"
         valueType="amount"
         :studyData="studyData"
         preferredCurrency="USD"
+        :lightVersion="isSubRow"
       />
     </template>
   </ComparisonExpandableRow>

--- a/src/components/comparison/ComparisonEnvironment.vue
+++ b/src/components/comparison/ComparisonEnvironment.vue
@@ -8,8 +8,8 @@
       :getValue="(study) => getTotalImpacts(study, true)"
       :getSubValues="(study) => getValuesByImpact(study, true)"
     >
-      <template #default="{ value }">
-        <ComparisonDefaultCell :value="value" valueType="number" />
+      <template #default="{ value, isSubRow }">
+        <ComparisonDefaultCell :value="value" valueType="number" :lightVersion="isSubRow" />
       </template>
     </ComparisonExpandableRow>
     <ComparisonExpandableRow
@@ -19,8 +19,8 @@
       :getValue="(study) => getTotalImpacts(study, false)"
       :getSubValues="(study) => getValuesByImpact(study, false)"
     >
-      <template #default="{ value }">
-        <ComparisonDefaultCell :value="value" valueType="number" />
+      <template #default="{ value, isSubRow }">
+        <ComparisonDefaultCell :value="value" valueType="number" :lightVersion="isSubRow" />
       </template>
     </ComparisonExpandableRow>
   </template>

--- a/src/components/comparison/ComparisonRow.vue
+++ b/src/components/comparison/ComparisonRow.vue
@@ -46,7 +46,7 @@ const values = computed(() => props.studies.map(study => props.getValue(study)))
   }
   
   tr td:not(:first-child) :deep(div.default-comparison-cell) {
-    @apply text-center text-sm py-1.5
+    @apply text-center py-1.5
   }
   tr td:nth-child(2) :deep(div.default-comparison-cell) {
     @apply rounded-l-full


### PR DESCRIPTION
## Contexte

Ceci est l'intégration de 2 retours (quick-win) de Marion:

On veut distinguer les sous-cellules des parties économiques & environnementales, et on veut aussi rendre plus lisible

## Changements

- Les cellules des sous rangs environnementaux et économiques ont une bordure bleue et un fond plus clair. Comme les sous-tags de la partie sociale
- On augmente la taille de police des cellules pour qu'elles aient la même taille que le reste du texte dans la page


| Avant | Après |
| - | - | 
| ![image](https://github.com/user-attachments/assets/f8d3a741-cef1-41e1-8d09-480d1c7545f6) | ![image](https://github.com/user-attachments/assets/3466eeb3-9bf3-4a63-a7a3-0c07d8e84184) |