### PR TITLE
feat: Add specific rows for Global warming on comparison page

### DIFF
--- a/src/components/StudyEnvironment.vue
+++ b/src/components/StudyEnvironment.vue
@@ -3,34 +3,39 @@
     <SectionTitle>
       <h1>Is the value chain environmentally sustainable?</h1>
     </SectionTitle>
+    <p>The approach to evaluate the environmental sustainability of the value chain is twofold.</p>
     <p>
-      The approach to evaluate the environmental sustainability of the value chain is twofold.
+      First, damages entailed by the value chain operations are calculated on
+      <strong>Resource depletion</strong>, <strong>Ecosystem quality</strong> and
+      <strong>Human health</strong>, as well as their contribution to
+      <strong>Climate change</strong> through the quantitative
+      <strong>Life Cycle Assessment (LCA)</strong>.
     </p>
     <p>
-      First, damages entailed by the value chain operations are calculated on <strong>Resource depletion</strong>,
-      <strong>Ecosystem quality</strong> and <strong>Human health</strong>, as well as their contribution
-      to <strong>Climate change</strong> through the quantitative <strong>Life Cycle Assessment (LCA)</strong>.
-    </p>
-    <p> 
-      Second, an <strong>exploratory assessment of biodiversity risks is provided</strong>.
-      The appraisal of the environmental sustainability of the value chain is carried out by combining quantitative and qualitative data.
+      Second, an <strong>exploratory assessment of biodiversity risks is provided</strong>. The
+      appraisal of the environmental sustainability of the value chain is carried out by combining
+      quantitative and qualitative data.
     </p>
     <p class="mt-4">
-      LCA inventories the material and energy flows used, produced or released by the activities of the value chain.
-      The substances emitted or consumed by the activities at each stage are recorded and measured.
-      According to their physical, chemical and biological nature, they activate cause-and-effect
-      chains that induce changes in the environment. These changes cause (or counteract) specific
-      environmental problems such as terrestrial acidification, freshwater deprivation or ecotoxicity.
-    </p><p>
-      LCA refers to the effects as <strong>“impacts”</strong> (the “midpoints” level). The consequences of these impacts 
-      on Natural Resources, Ecosystem Quality and Human Health are referred to as <strong>“damage”</strong>. 
-      LCA also enables to measure the contribution of the value chain to climate change through its <strong>carbon footprint</strong>.
+      LCA inventories the material and energy flows used, produced or released by the activities of
+      the value chain. The substances emitted or consumed by the activities at each stage are
+      recorded and measured. According to their physical, chemical and biological nature, they
+      activate cause-and-effect chains that induce changes in the environment. These changes cause
+      (or counteract) specific environmental problems such as terrestrial acidification, freshwater
+      deprivation or ecotoxicity.
+    </p>
+    <p>
+      LCA refers to the effects as <strong>“impacts”</strong> (the “midpoints” level). The
+      consequences of these impacts on Natural Resources, Ecosystem Quality and Human Health are
+      referred to as <strong>“damage”</strong>. LCA also enables to measure the contribution of the
+      value chain to climate change through its <strong>carbon footprint</strong>.
     </p>
 
     <QuestionTitle>Which sub-chain contributes the most to environmental damages?</QuestionTitle>
     <p>
-      Sub-chains can be compared according to the damage they generate in the three areas of protection. 
-      This highlights the gaps between them and helps determine actions for environmental improvements.
+      Sub-chains can be compared according to the damage they generate in the three areas of
+      protection. This highlights the gaps between them and helps determine actions for
+      environmental improvements.
     </p>
     <div class="unit-selection">
       <div class="unit-selection-title">Unit Selection</div>
@@ -39,13 +44,13 @@
           title="Scope of the results"
           :options="perUnits"
           :selected="selectedPerUnit"
-          @update:selected="$event => selectedPerUnit = $event"
+          @update:selected="($event) => (selectedPerUnit = $event)"
         />
         <RadioInput
           title="Unit of the impact"
           :options="units"
           :selected="selectedUnit"
-          @update:selected="$event => selectedUnit = $event"
+          @update:selected="($event) => (selectedUnit = $event)"
         />
       </div>
     </div>
@@ -62,7 +67,7 @@ import { computed, ref } from 'vue'
 import SectionTitle from '@typography/SectionTitle.vue'
 import ImpactDataviz from '@components/study/environment/ImpactDataviz.vue'
 import { ACVImpacts } from '@utils/misc.js'
-import QuestionTitle from "@components/study/QuestionTitle.vue"
+import QuestionTitle from '@components/study/QuestionTitle.vue'
 import RadioInput from '@components/study/RadioInput.vue'
 
 const props = defineProps({
@@ -75,43 +80,59 @@ const allBarChartsData = computed(() => {
     if (!majorImpactsNames.includes(impact.name)) {
       return false
     }
-    return selectedUnit.value === "PT" ? (impact.unit === 'Pt') : (impact.unit !== 'Pt')
-    })
+    return selectedUnit.value === 'PT' ? impact.unit === 'Pt' : impact.unit !== 'Pt'
+  })
 
   return impactsToDrawOnGraph
 })
 
 const yearlyVolumes = computed(() => {
   var result = {}
-  props.studyData.acvData.valuechains.map(item => {
+  props.studyData.acvData.valuechains.map((item) => {
     result[item.name] = item.volume
   })
   return result
 })
 
 const units = [
-  { label: 'Different units', value: 'OTHER', subtitle: 'Each impact is expressed in its own unit' },
-  { label: 'Single score (Pt)', value: 'PT', subtitle: 'Different impacts (climate, health, water etc.) are expressed in a single weighted unit.' },
-];
-
-const perUnits = [
-  { label: "Impact per functional unit", value: "functional unit", subtitle: "Compare best performing production systems" },
-  { label: "Total impact per year", value: "year", subtitle: "See which sub-chain currently has most impact in the country" },
+  {
+    label: 'Different units',
+    value: 'OTHER',
+    subtitle: 'Each impact is expressed in its own unit'
+  },
+  {
+    label: 'Single score (Pt)',
+    value: 'PT',
+    subtitle:
+      'Different impacts (climate, health, water etc.) are expressed in a single weighted unit.'
+  }
 ]
 
-const selectedUnit = ref(units[0].value);
-const selectedPerUnit = ref(perUnits[0].value);
+const perUnits = [
+  {
+    label: 'Impact per functional unit',
+    value: 'functional unit',
+    subtitle: 'Compare best performing production systems'
+  },
+  {
+    label: 'Total impact per year',
+    value: 'year',
+    subtitle: 'See which sub-chain currently has most impact in the country'
+  }
+]
 
+const selectedUnit = ref(units[0].value)
+const selectedPerUnit = ref(perUnits[0].value)
 </script>
 
 <style scoped lang="scss">
 .unit-selection {
   margin: 32px 0;
-  
+
   .unit-selection-title {
     text-transform: uppercase;
     font-weight: 700;
-    color: #8A8A8A;
+    color: #8a8a8a;
     margin-bottom: 16px;
   }
 

--- a/src/components/study/environment/ImpactDataviz.vue
+++ b/src/components/study/environment/ImpactDataviz.vue
@@ -1,7 +1,14 @@
 <template>
   <div>
-    <h3>What are the impacts of the different sub-chains on {{ detailsToDisplay.label ? detailsToDisplay.label : detailsToDisplay.name }}?</h3>
-    <InfoTitle :title="detailsToDisplay.label ? detailsToDisplay.label : detailsToDisplay.name" :information="detailsToDisplay.helpBoxText" class="my-4" />
+    <h3>
+      What are the impacts of the different sub-chains on
+      {{ detailsToDisplay.label ? detailsToDisplay.label : detailsToDisplay.name }}?
+    </h3>
+    <InfoTitle
+      :title="detailsToDisplay.label ? detailsToDisplay.label : detailsToDisplay.name"
+      :information="detailsToDisplay.helpBoxText"
+      class="my-4"
+    />
     <BarChart :options="populatedBarChartData" @chart-series-click="handleDataChartSeriesClick" />
     <div v-if="selectedValueChain">
       <MiniChartContainer
@@ -30,13 +37,13 @@ import { getColor } from '@utils/colors.js'
 import { ACVImpacts } from '@utils/misc.js'
 
 const props = defineProps({
-    impact: Object,
-    perUnit: String,
-    volumes: Object
+  impact: Object,
+  perUnit: String,
+  volumes: Object
 })
 
 const detailsToDisplay = computed(() => {
-  var details = ACVImpacts.find(item => item.name == props.impact.name)
+  var details = ACVImpacts.find((item) => item.name == props.impact.name)
   return details
 })
 
@@ -44,8 +51,7 @@ const selectedValueChain = ref(null)
 const handleDataChartSeriesClick = (event) => {
   if (selectedValueChain.value == event.name) {
     selectedValueChain.value = null
-  }
-  else {
+  } else {
     selectedValueChain.value = event.name
   }
 }
@@ -54,18 +60,19 @@ const detailBarChartOptions = computed(() => {
   var tooltip = {}
   var labels = []
   var values = []
-  props.impact.values.filter(item => item.valuechain_name == selectedValueChain.value)
-  .forEach(item => {
-    labels.push(item.actor_name)
-    var color = getColor(item.valuechain_name, true)
-    values.push({
+  props.impact.values
+    .filter((item) => item.valuechain_name == selectedValueChain.value)
+    .forEach((item) => {
+      labels.push(item.actor_name)
+      var color = getColor(item.valuechain_name, true)
+      values.push({
         value: item.value,
         itemStyle: {
           color
         }
+      })
+      tooltip[item.actor_name] = `${formatNumber(item.value)} per functional unit`
     })
-    tooltip[item.actor_name] = `${formatNumber(item.value)} per functional unit`
-  })
   let barChartExample = {
     title: {
       text: ''
@@ -132,10 +139,11 @@ const populatedBarChartData = computed(() => {
   for (var value of props.impact.values) {
     if (!(value.valuechain_name in valuesByChain)) {
       valuesByChain[value.valuechain_name] = 0
-      tooltip[value.valuechain_name] = ""
+      tooltip[value.valuechain_name] = ''
     }
     valuesByChain[value.valuechain_name] += value.value
-    tooltip[value.valuechain_name] += `<b>${value.actor_name}</b>: ${formatNumber(value.value)} per functional unit<br>`
+    tooltip[value.valuechain_name] +=
+      `<b>${value.actor_name}</b>: ${formatNumber(value.value)} per functional unit<br>`
   }
 
   const items = Object.keys(valuesByChain).map((chainName) => {
@@ -160,5 +168,4 @@ const populatedBarChartData = computed(() => {
 })
 </script>
 
-<style scoped lang="scss">
-</style>
+<style scoped lang="scss"></style>

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,69 +1,73 @@
-import { computed } from "vue";
+import { computed } from 'vue'
 
 export function useActorsAndStages(props) {
-  const stages = computed(() => props.studyData.ecoData.stages);
-  const actors = computed(() => props.studyData.ecoData.actors);
+  const stages = computed(() => props.studyData.ecoData.stages)
+  const actors = computed(() => props.studyData.ecoData.actors)
 
   return {
     stages,
-    actors,
-  };
+    actors
+  }
 }
 
-
 export const ACVImpacts = [
-    {
-        name: "Global warming",
-        children: []
-    },
-    {
-        name: "Climate Change",
-        children: ["Global warming, Human health",
-            "Global warming. Freshwater ecosystems",
-            "Global warming. Terrestrial ecosystems",
-        ],
-        helpBoxText: "LCA measures the the Value Chain's contribution to climate change by a <b>carbon footprint</b>, translating all the GHG emissions into a quantity of released CO2 that would have the equivalent effect. The unit is kg of CO2 equivalent."
-    },
-    {
-        name: "Human health",
-        label: "Human health hazard",
-        children: ["Global warming, Human health",
-            "Stratospheric ozone depletion",
-            "Ionizing radiation",
-            "Ozone formation, Human health",
-            "Fine particulate matter formation",
-            "Human carcinogenic toxicity",
-            "Human non-carcinogenic toxicity",
-            "Water consumption, Human health"
-        ],
-        helpBoxText: "LCA aims at capturing negative effects on quality of life (morbidity) and life expectancy (mortality). The indicator is expressed by DALY (Disability Adjusted Loss of Life Years) that refers to Reduction of the potential number of healthy life years due to premature morbidity or mortality."
-    },
-    {
-        name: "Ecosystems",
-        label: "Ecosystem degradation",
-        children: ["Global warming. Terrestrial ecosystems",
-            "Global warming. Freshwater ecosystems",
-            "Ozone formation. Terrestrial ecosystems",
-            "Terrestrial acidification",
-            "Freshwater eutrophication",
-            "Marine eutrophication",
-            "Terrestrial ecotoxicity",
-            "Freshwater ecotoxicity",
-            "Marine ecotoxicity",
-            "Land use",
-            "Water consumption. Terrestrial ecosystem",
-            "Water consumption. Aquatic ecosystems"
-        ],
-        helpBoxText: "LCA focuses on the impairment in the functions and structure of natural ecosystems through a variety of damage to all kinds of local wildlife species leading to loss integrated over time. The usual indicator that measures the impact on Ecosystem Quality is the Potentially Disappeared Fraction of species (PDF) during one year. The unit is expressed by “species.yr”."
-    },
-    {
-        name: "Resources",
-        label: "Resources depletion",
-        children: ["Mineral resource scarcity",
-            "Fossil resource scarcity"
-        ],
-        helpBoxText: "LCA aims at capturing depletion of resources by focusing on the level of non-renewable stocks and the rate of use of renewable resources to their replacement. The indicator is the increased cost to continue extractions which is expressed by US $."
-    }
+  {
+    name: 'Global warming',
+    children: []
+  },
+  {
+    name: 'Climate Change',
+    children: [
+      'Global warming, Human health',
+      'Global warming. Freshwater ecosystems',
+      'Global warming. Terrestrial ecosystems'
+    ],
+    helpBoxText:
+      "LCA measures the the Value Chain's contribution to climate change by a <b>carbon footprint</b>, translating all the GHG emissions into a quantity of released CO2 that would have the equivalent effect. The unit is kg of CO2 equivalent."
+  },
+  {
+    name: 'Human health',
+    label: 'Human health hazard',
+    children: [
+      'Global warming, Human health',
+      'Stratospheric ozone depletion',
+      'Ionizing radiation',
+      'Ozone formation, Human health',
+      'Fine particulate matter formation',
+      'Human carcinogenic toxicity',
+      'Human non-carcinogenic toxicity',
+      'Water consumption, Human health'
+    ],
+    helpBoxText:
+      'LCA aims at capturing negative effects on quality of life (morbidity) and life expectancy (mortality). The indicator is expressed by DALY (Disability Adjusted Loss of Life Years) that refers to Reduction of the potential number of healthy life years due to premature morbidity or mortality.'
+  },
+  {
+    name: 'Ecosystems',
+    label: 'Ecosystem degradation',
+    children: [
+      'Global warming. Terrestrial ecosystems',
+      'Global warming. Freshwater ecosystems',
+      'Ozone formation. Terrestrial ecosystems',
+      'Terrestrial acidification',
+      'Freshwater eutrophication',
+      'Marine eutrophication',
+      'Terrestrial ecotoxicity',
+      'Freshwater ecotoxicity',
+      'Marine ecotoxicity',
+      'Land use',
+      'Water consumption. Terrestrial ecosystem',
+      'Water consumption. Aquatic ecosystems'
+    ],
+    helpBoxText:
+      'LCA focuses on the impairment in the functions and structure of natural ecosystems through a variety of damage to all kinds of local wildlife species leading to loss integrated over time. The usual indicator that measures the impact on Ecosystem Quality is the Potentially Disappeared Fraction of species (PDF) during one year. The unit is expressed by “species.yr”.'
+  },
+  {
+    name: 'Resources',
+    label: 'Resources depletion',
+    children: ['Mineral resource scarcity', 'Fossil resource scarcity'],
+    helpBoxText:
+      'LCA aims at capturing depletion of resources by focusing on the level of non-renewable stocks and the rate of use of renewable resources to their replacement. The indicator is the increased cost to continue extractions which is expressed by US $.'
+  }
 ]
 
 export function clearLocalStorage() {

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -13,58 +13,24 @@ export function useActorsAndStages(props) {
 export const ACVImpacts = [
   {
     name: 'Global warming',
-    children: []
-  },
-  {
-    name: 'Climate Change',
-    children: [
-      'Global warming, Human health',
-      'Global warming. Freshwater ecosystems',
-      'Global warming. Terrestrial ecosystems'
-    ],
     helpBoxText:
       "LCA measures the the Value Chain's contribution to climate change by a <b>carbon footprint</b>, translating all the GHG emissions into a quantity of released CO2 that would have the equivalent effect. The unit is kg of CO2 equivalent."
   },
   {
     name: 'Human health',
     label: 'Human health hazard',
-    children: [
-      'Global warming, Human health',
-      'Stratospheric ozone depletion',
-      'Ionizing radiation',
-      'Ozone formation, Human health',
-      'Fine particulate matter formation',
-      'Human carcinogenic toxicity',
-      'Human non-carcinogenic toxicity',
-      'Water consumption, Human health'
-    ],
     helpBoxText:
       'LCA aims at capturing negative effects on quality of life (morbidity) and life expectancy (mortality). The indicator is expressed by DALY (Disability Adjusted Loss of Life Years) that refers to Reduction of the potential number of healthy life years due to premature morbidity or mortality.'
   },
   {
     name: 'Ecosystems',
     label: 'Ecosystem degradation',
-    children: [
-      'Global warming. Terrestrial ecosystems',
-      'Global warming. Freshwater ecosystems',
-      'Ozone formation. Terrestrial ecosystems',
-      'Terrestrial acidification',
-      'Freshwater eutrophication',
-      'Marine eutrophication',
-      'Terrestrial ecotoxicity',
-      'Freshwater ecotoxicity',
-      'Marine ecotoxicity',
-      'Land use',
-      'Water consumption. Terrestrial ecosystem',
-      'Water consumption. Aquatic ecosystems'
-    ],
     helpBoxText:
       'LCA focuses on the impairment in the functions and structure of natural ecosystems through a variety of damage to all kinds of local wildlife species leading to loss integrated over time. The usual indicator that measures the impact on Ecosystem Quality is the Potentially Disappeared Fraction of species (PDF) during one year. The unit is expressed by “species.yr”.'
   },
   {
     name: 'Resources',
     label: 'Resources depletion',
-    children: ['Mineral resource scarcity', 'Fossil resource scarcity'],
     helpBoxText:
       'LCA aims at capturing depletion of resources by focusing on the level of non-renewable stocks and the rate of use of renewable resources to their replacement. The indicator is the increased cost to continue extractions which is expressed by US $.'
   }


### PR DESCRIPTION
Tache Notion (spec) : https://www.notion.so/le-basic/Ajouter-Global-warming-page-de-comparaison-1346afc9ad64800aae07cd14b7c71f64

## Contexte

On vaut ajouter deux rangs sous les indicateurs environnementaux en `pt` pour extraire le Global warming (en eq CO2)

![image](https://github.com/user-attachments/assets/d5220ca5-e534-42af-bf73-d8b438717562)


## Changements

- Un peu de boyscout
- Ajout des rows global warming (en refactorant un peu en meme temps: merge de 2 commits que j'avais fait à la base)
- :warning: Fix de l'algo qui calcule les impacts. Puisqu'on loopait sur les value chains, on tombait sur la value chain `Total production` (volume: total, impact: 0), ce qui divisait par deux l'impact réel par unité fonctionelle
  - J'ai vérifié à la main les calculs, ça colle maintenant bien avec la page d'environnement (sur 2 études cashew) 