### PR TITLE
feat: Add global stage net operating profit in comparison

### DIFF
--- a/src/charts/charts.js
+++ b/src/charts/charts.js
@@ -4,372 +4,407 @@ const RADIUSES_MINI_PIE = ['20%', '40%']
 const RIADUSES_PIE = ['50%', '75%']
 
 /*
-* RING CHART
-*/
+ * RING CHART
+ */
 export const getRingChart = (items, tooltip, title) => {
-    return {
-        title: {
-            text: title,
-            left: 'center',
-            top: 0
-        },
-        tooltip: {
-            trigger: 'item',
-            formatter: function (info) {
-                return tooltip[info.name]
-            }
-        },
-        series: [
-            {
-                label: {
-                    position: 'outer',
-                    //alignTo: 'labelLine',
-                    overflow: 'break',
-                    bleedMargin: 0,
-                    ellipsis: '..',
-                    width: 100,
-                    formatter: params => params.data.label || params.data.name
-                },
-                type: 'pie',
-                data: items,
-                radius: RIADUSES_PIE,
-                itemStyle: {
-                    color: function (info) {
-                        return getColor(info.name)
-                    }
-                }
-            }
-        ]
-    };
-}
-
-/*
-*  STACKED BAR CHART
-*/
-export const getStackedBarChart = (label, data, maxValue, prettyAmount, convertAmount) => {
-    const seriesData = data.map(({ value, name, color }) => ({
-        name,
-        type: 'bar',
-        stack: 'stack',
+  return {
+    title: {
+      text: title,
+      left: 'center',
+      top: 0
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: function (info) {
+        return tooltip[info.name]
+      }
+    },
+    series: [
+      {
         label: {
-            show: true,
-            position: 'right',
-            formatter: () => name,
+          position: 'outer',
+          //alignTo: 'labelLine',
+          overflow: 'break',
+          bleedMargin: 0,
+          ellipsis: '..',
+          width: 100,
+          formatter: (params) => params.data.label || params.data.name
         },
-        labelLayout: {
-          hideOverlap: true,
-        },
-        data: [convertAmount(value)],
+        type: 'pie',
+        data: items,
+        radius: RIADUSES_PIE,
         itemStyle: {
-            color
+          color: function (info) {
+            return getColor(info.name)
+          }
         }
-    }))
-    const totalText = prettyAmount(convertAmount(data.reduce((total, item) => total + item.value, 0)))
-
-    return {
-        title: {
-            text: totalText,
-            top: '5%',
-            left: '40%'
-        },
-        tooltip: {
-            trigger: 'axis',
-            axisPointer: {
-                type: 'shadow',
-            },
-            formatter: (params) => {
-                return params.map(({ seriesName, value }) => `${seriesName}: ${prettyAmount(value)}`).join('<br />')
-            },
-        },
-        xAxis: {
-            type: 'category',
-            data: [label],
-            axisLabel: {
-                interval: 0,
-                fontSize: 20,
-                textColor: '#8A8A8A',
-                fontWeight: 'bold'
-            },
-        },
-        yAxis: {
-            show: false,
-            max: convertAmount(maxValue)
-        },
-        series: seriesData,
-    }
+      }
+    ]
+  }
 }
 
 /*
-* SELECTABLE BAR CHART
-*/
-export const getSelectableBarChart = (items, currentItem, tooltip, formatLabel, isEnvironment = false) => {
-    let labels = []
-    let values = []
-    items.map(item => {
-        labels.push(item.name)
-        // const color = currentItem === item.name ? SELECTED_COLOR : getColor(item.name)
-        // const emphasisColor = currentItem === item.name ? SELECTED_COLOR_HOVER : getColor(item.name) + "B3"
-        const color = getColor(item.name, isEnvironment)
-        const emphasisColor = color + "B3"
-        values.push({
-            value: item.value,
-            emphasisColor,
-            itemStyle: {
-                color,
-                ... (
-                    currentItem === item.name
-                        ? {
-                            borderColor: "black",
-                            borderWidth: 2,
-                            borderRadius: 5
-                        } : {})
+ *  STACKED BAR CHART
+ */
+export const getStackedBarChart = (label, data, maxValue, prettyAmount, convertAmount) => {
+  const seriesData = data.map(({ value, name, color }) => ({
+    name,
+    type: 'bar',
+    stack: 'stack',
+    label: {
+      show: true,
+      position: 'right',
+      formatter: () => name
+    },
+    labelLayout: {
+      hideOverlap: true
+    },
+    data: [convertAmount(value)],
+    itemStyle: {
+      color
+    }
+  }))
+  const totalText = prettyAmount(convertAmount(data.reduce((total, item) => total + item.value, 0)))
+
+  return {
+    title: {
+      text: totalText,
+      top: '5%',
+      left: '40%'
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'shadow'
+      },
+      formatter: (params) => {
+        return params
+          .map(({ seriesName, value }) => `${seriesName}: ${prettyAmount(value)}`)
+          .join('<br />')
+      }
+    },
+    xAxis: {
+      type: 'category',
+      data: [label],
+      axisLabel: {
+        interval: 0,
+        fontSize: 20,
+        textColor: '#8A8A8A',
+        fontWeight: 'bold'
+      }
+    },
+    yAxis: {
+      show: false,
+      max: convertAmount(maxValue)
+    },
+    series: seriesData
+  }
+}
+
+/*
+ * SELECTABLE BAR CHART
+ */
+export const getSelectableBarChart = (
+  items,
+  currentItem,
+  tooltip,
+  formatLabel,
+  isEnvironment = false
+) => {
+  let labels = []
+  let values = []
+  items.map((item) => {
+    labels.push(item.name)
+    // const color = currentItem === item.name ? SELECTED_COLOR : getColor(item.name)
+    // const emphasisColor = currentItem === item.name ? SELECTED_COLOR_HOVER : getColor(item.name) + "B3"
+    const color = getColor(item.name, isEnvironment)
+    const emphasisColor = color + 'B3'
+    values.push({
+      value: item.value,
+      emphasisColor,
+      itemStyle: {
+        color,
+        ...(currentItem === item.name
+          ? {
+              borderColor: 'black',
+              borderWidth: 2,
+              borderRadius: 5
             }
-        })
+          : {})
+      }
     })
-    return {
-        xAxis: {
-            data: labels,
-            type: 'category',
-            left: 0,
-            axisLabel: {
-                hideOverlap: false,
-                align: 'center',
-                fontSize: 15,
-                fontWeight: 500,
-                overflow: 'break',
-                /*TODO : il faut calculer la largeur max des labels (width) du graph bar en fonction de la taille de la fenêtre
+  })
+  return {
+    xAxis: {
+      data: labels,
+      type: 'category',
+      left: 0,
+      axisLabel: {
+        hideOverlap: false,
+        align: 'center',
+        fontSize: 15,
+        fontWeight: 500,
+        overflow: 'break',
+        /*TODO : il faut calculer la largeur max des labels (width) du graph bar en fonction de la taille de la fenêtre
                 pour que la propriété 'overflow' fonctionne et que le label soit renvoyé à la ligne automatiquement
                 width: 100,*/
-                interval: 0,
-            },
-            axisTick: {
-                alignWithLabel: true
-            },
-        },
-        label: {
-            show: true,
-            position: 'top',
-            formatter: function (d) {
-                if (!d.data) {
-                    return ""
-                }
-                return formatLabel ? formatLabel(d.data.value) : formatNumber(d.data.value)
-            },
-            textStyle: {
-                fontSize: 22,
-                fontWeight: 500,
-            }
-        },
-        tooltip: {
-            trigger: 'item',
-            formatter: function (info) {
-                return tooltip[info.name]
-            }
-        },
-        yAxis: {
-            show: false
-        },
-        series: [
-            {
-                type: 'bar',
-                data: values,
-                barCategoryGap: "20%"
-            }
-        ]
-    };
+        interval: 0
+      },
+      axisTick: {
+        alignWithLabel: true
+      }
+    },
+    label: {
+      show: true,
+      position: 'top',
+      formatter: function (d) {
+        if (!d.data) {
+          return ''
+        }
+        return formatLabel ? formatLabel(d.data.value) : formatNumber(d.data.value)
+      },
+      textStyle: {
+        fontSize: 22,
+        fontWeight: 500
+      }
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: function (info) {
+        return tooltip[info.name]
+      }
+    },
+    yAxis: {
+      show: false
+    },
+    series: [
+      {
+        type: 'bar',
+        data: values,
+        barCategoryGap: '20%'
+      }
+    ]
+  }
 }
 
 export const getNumberOfActorsData = (stages, actors, currentStage) => {
-    let tooltip = {}
-    const items = stages.value.map(stage => {
-        const stageActors = actors.value.filter(actor => actor.stage === stage.name)
+  let tooltip = {}
+  const items = stages.value
+    .map((stage) => {
+      const stageActors = actors.value.filter((actor) => actor.stage === stage.name)
 
-        const subTotal = stageActors
-            .reduce((res, actor) => res + actor.numberOfActors || 0, 0)
-        if (subTotal !== 0) {
-            let toolTipValue = ""
-            for (const actor of stageActors) {
-                toolTipValue += `${actor.name}: ${formatNumber(actor.numberOfActors)}<br>`
-            }
-
-            tooltip[stage.name] = toolTipValue
-            return {
-                name: stage.name,
-                value: subTotal
-            }
+      const subTotal = stageActors.reduce((res, actor) => res + actor.numberOfActors || 0, 0)
+      if (subTotal !== 0) {
+        let toolTipValue = ''
+        for (const actor of stageActors) {
+          toolTipValue += `${actor.name}: ${formatNumber(actor.numberOfActors)}<br>`
         }
-    }).filter(item => !!item)
 
-    return getSelectableBarChart(items, currentStage.value, tooltip)
-}
-
-export const getNetOperatingProfitData = (stages, actors, convertAmount, prettyAmount, currentStage) => {
-    let tooltip = {}
-
-    let total = 0
-    const items = stages.value.map(stage => {
-        const stageActors = actors.value.filter(actor => actor.stage === stage.name)
-        const subTotal = convertAmount.value(stageActors
-            .reduce((res, actor) => res + actor.netOperatingProfit || 0, 0))
-        if (subTotal !== 0) {
-            total += subTotal
-            let toolTipValue = "";
-            for (const actor of stageActors) {
-                var convertedActorProfit = convertAmount.value(actor.netOperatingProfit)
-                toolTipValue += `${actor.name}: ${prettyAmount.value(convertedActorProfit)} (${formatPercent(convertedActorProfit / subTotal)})<br>`
-            }
-            tooltip[stage.name] = toolTipValue
-            return {
-                name: stage.name,
-                value: subTotal
-            }
-        }
-    }).filter(item => !!item)
-    return getSelectableBarChart(items, currentStage.value, tooltip, (value) => `${prettyAmount.value(value)} (${formatPercent(value / total)})`)
-}
-
-export const getPublicFinancesData = (stages, actors, convertAmount, prettyAmount, currentStage) => {
-
-    let tooltip = {}
-    const items = stages.value.map(({ name: stageName }) => {
-        const stageActors = actors.value.filter(actor => actor.stage === stageName)
-
-        const subTotal = convertAmount.value(stageActors.reduce((res, actor) => res + actor.publicFundsBalance, 0))
-        tooltip[stageName] = `${prettyAmount.value(subTotal)}`
+        tooltip[stage.name] = toolTipValue
         return {
-            name: stageName,
-            value: subTotal
+          name: stage.name,
+          value: subTotal
         }
-    }).filter(item => !!item && item.value > 0)
-    return getSelectableBarChart(items, currentStage.value, tooltip, prettyAmount.value)
+      }
+    })
+    .filter((item) => !!item)
+
+  return getSelectableBarChart(items, currentStage.value, tooltip)
 }
 
+export const getNetOperatingProfitData = (
+  stages,
+  actors,
+  convertAmount,
+  prettyAmount,
+  currentStage
+) => {
+  let tooltip = {}
+
+  let total = 0
+  const items = stages.value
+    .map((stage) => {
+      const stageActors = actors.value.filter((actor) => actor.stage === stage.name)
+      const subTotal = convertAmount.value(
+        stageActors.reduce((res, actor) => res + actor.netOperatingProfit || 0, 0)
+      )
+      if (subTotal !== 0) {
+        total += subTotal
+        let toolTipValue = ''
+        for (const actor of stageActors) {
+          var convertedActorProfit = convertAmount.value(actor.netOperatingProfit)
+          toolTipValue += `${actor.name}: ${prettyAmount.value(convertedActorProfit)} (${formatPercent(convertedActorProfit / subTotal)})<br>`
+        }
+        tooltip[stage.name] = toolTipValue
+        return {
+          name: stage.name,
+          value: subTotal
+        }
+      }
+    })
+    .filter((item) => !!item)
+  return getSelectableBarChart(
+    items,
+    currentStage.value,
+    tooltip,
+    (value) => `${prettyAmount.value(value)} (${formatPercent(value / total)})`
+  )
+}
+
+export const getPublicFinancesData = (
+  stages,
+  actors,
+  convertAmount,
+  prettyAmount,
+  currentStage
+) => {
+  let tooltip = {}
+  const items = stages.value
+    .map(({ name: stageName }) => {
+      const stageActors = actors.value.filter((actor) => actor.stage === stageName)
+
+      const subTotal = convertAmount.value(
+        stageActors.reduce((res, actor) => res + actor.publicFundsBalance, 0)
+      )
+      tooltip[stageName] = `${prettyAmount.value(subTotal)}`
+      return {
+        name: stageName,
+        value: subTotal
+      }
+    })
+    .filter((item) => !!item && item.value > 0)
+  return getSelectableBarChart(items, currentStage.value, tooltip, prettyAmount.value)
+}
 
 /*
-* MINI BAR CHART
-*/
+ * MINI BAR CHART
+ */
 
 export const getMiniBarChart = (items, tooltip, formatLabel, color) => {
-    let labels = []
-    let values = []
-    items.map(item => {
-        labels.push(item.name)
-        // code temporaire pour récupérer une couleur, il faudra récupérer la couleur du stage quand pertinent à l'avenir
-        if (!color) {
-            color = getColor(item.name)
-        }
-        const emphasisColor = color + "B3"
-        values.push({
-            value: item.value,
-            emphasisColor,
-            itemStyle: {
-                color,
-            }
-        })
+  let labels = []
+  let values = []
+  items.map((item) => {
+    labels.push(item.name)
+    // code temporaire pour récupérer une couleur, il faudra récupérer la couleur du stage quand pertinent à l'avenir
+    if (!color) {
+      color = getColor(item.name)
+    }
+    const emphasisColor = color + 'B3'
+    values.push({
+      value: item.value,
+      emphasisColor,
+      itemStyle: {
+        color
+      }
     })
-    return {
-        xAxis: {
-            data: labels,
-            left: 0,
-            axisLabel: {
-                fontSize: 15,
-                fontWeight: 500,
-                //color: '#e2e0e0',
-                interval: 0,
-                rotate: -10,
-                margin: 20
-            }
-        },
-        label: {
-            show: true,
-            position: 'top',
-            formatter: function (d) {
-                if (!d.data) {
-                    return ""
-                }
-                return formatLabel ? formatLabel(d.data.value) : formatNumber(d.data.value)
-            },
-            textStyle: {
-                fontSize: 22,
-                fontWeight: 500,
-            },
-            //color: '#e2e0e0'
-        },
-        tooltip: {
-            trigger: 'item',
-            formatter: function (info) {
-                return tooltip[info.name]
-            }
-        },
-        yAxis: {
-            show: false
-        },
-        series: [
-            {
-                type: 'bar',
-                data: values,
-                barCategoryGap: "5%"
-            }
-        ]
-    };
+  })
+  return {
+    xAxis: {
+      data: labels,
+      left: 0,
+      axisLabel: {
+        fontSize: 15,
+        fontWeight: 500,
+        //color: '#e2e0e0',
+        interval: 0,
+        rotate: -10,
+        margin: 20
+      }
+    },
+    label: {
+      show: true,
+      position: 'top',
+      formatter: function (d) {
+        if (!d.data) {
+          return ''
+        }
+        return formatLabel ? formatLabel(d.data.value) : formatNumber(d.data.value)
+      },
+      textStyle: {
+        fontSize: 22,
+        fontWeight: 500
+      }
+      //color: '#e2e0e0'
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: function (info) {
+        return tooltip[info.name]
+      }
+    },
+    yAxis: {
+      show: false
+    },
+    series: [
+      {
+        type: 'bar',
+        data: values,
+        barCategoryGap: '5%'
+      }
+    ]
+  }
 }
 
 /*
-*  MINI PIE CHART
-*/
+ *  MINI PIE CHART
+ */
 export const getMiniPieChart = (data, title, valueFormatter) => {
-    const titleItem = {
-        text: title,
-        left: 'center',
-        top: 0
-    }
-    let tooltip = {}
-    data.map(item => tooltip[item.name] = `<strong>${item.name}</strong>: ${valueFormatter ? valueFormatter(item.value) : formatNumber(item.value)}`)
-    data = data.filter(item => item.value !== 0)
+  const titleItem = {
+    text: title,
+    left: 'center',
+    top: 0
+  }
+  let tooltip = {}
+  data.map(
+    (item) =>
+      (tooltip[item.name] =
+        `<strong>${item.name}</strong>: ${valueFormatter ? valueFormatter(item.value) : formatNumber(item.value)}`)
+  )
+  data = data.filter((item) => item.value !== 0)
 
-    return {
-        titleItem,
-        tooltip: {
-            trigger: 'item',
-            formatter: function (info) {
-                return tooltip[info.name]
-            }
+  return {
+    titleItem,
+    tooltip: {
+      trigger: 'item',
+      formatter: function (info) {
+        return tooltip[info.name]
+      }
+    },
+    series: [
+      {
+        type: 'pie',
+        data,
+        radius: RADIUSES_MINI_PIE,
+        label: {
+          width: 120,
+          overflow: 'break',
+          //color: "#e2e0e0",
+          fontSize: 15
         },
-        series: [
-            {
-                type: 'pie',
-                data,
-                radius: RADIUSES_MINI_PIE,
-                label: {
-                    width: 120,
-                    overflow: 'break',
-                    //color: "#e2e0e0",
-                    fontSize: 15
-                },
-                labelLine: {
-                    length: 20,
-                    length2: 10,
-                    smooth: true,
-                },
-            }
-        ]
-    };
+        labelLine: {
+          length: 20,
+          length2: 10,
+          smooth: true
+        }
+      }
+    ]
+  }
 }
 
 export const getNetOperatingProfitByTypeOfActorData = (actors, convertAmount, prettyAmount) => {
-    let data = actors.map(actor => {
-        return {
-            value: convertAmount(actor.netOperatingProfit || 0),
-            name: actor.name
-        }
-    })
-    return getMiniPieChart(data, 'By type of actor', prettyAmount)
+  let data = actors.map((actor) => {
+    return {
+      value: convertAmount(actor.netOperatingProfit || 0),
+      name: actor.name
+    }
+  })
+  return getMiniPieChart(data, 'By type of actor', prettyAmount)
 }
 
 export const getNumberOfActorsByTypeOfActorData = (actors) => {
-    let data = actors.map(actor => ({
-        value: actor.numberOfActors || 10,
-        name: actor.name
-    }))
-    return getMiniPieChart(data, 'By actor')
+  let data = actors.map((actor) => ({
+    value: actor.numberOfActors || 10,
+    name: actor.name
+  }))
+  return getMiniPieChart(data, 'By actor')
 }

--- a/src/components/comparison/comparisonConfig/economics.js
+++ b/src/components/comparison/comparisonConfig/economics.js
@@ -78,25 +78,25 @@ function getJobsByStage(studyData) {
 }
 
 function getNetOperatingProfitPerProducer(studyData) {
-  if (!studyData.metrics.eco?.netOperatingProfitPerActor) {
+  if (!studyData.metrics.eco?.netOperatingProfit) {
     return null
   }
 
-  return studyData.metrics.eco.netOperatingProfitPerActor?.Producers?.profitPerActor
+  return studyData.metrics.eco.netOperatingProfit?.Producers?.profitPerActor
 }
 
 function getNetOperatingProfitForOtherStages(studyData) {
-  if (!studyData.metrics.eco?.netOperatingProfitPerActor) {
+  if (!studyData.metrics.eco?.netOperatingProfit) {
     return {}
   }
 
   const netOperatingProfitForOtherStages = {}
-  const nonProducerStages = Object.keys(studyData.metrics.eco?.netOperatingProfitPerActor).filter(
+  const nonProducerStages = Object.keys(studyData.metrics.eco?.netOperatingProfit).filter(
     (stageName) => stageName !== 'Producers'
   )
   nonProducerStages.forEach((stageName) => {
     netOperatingProfitForOtherStages[buildPerStageName(stageName)] =
-      studyData.metrics.eco.netOperatingProfitPerActor?.[stageName]?.profitPerActor
+      studyData.metrics.eco.netOperatingProfit?.[stageName]?.profitPerActor
   })
   return netOperatingProfitForOtherStages
 }

--- a/src/components/comparison/comparisonConfig/economics.js
+++ b/src/components/comparison/comparisonConfig/economics.js
@@ -34,10 +34,17 @@ export const economicsConfig = [
     format: 'number'
   },
   {
+    title: 'Total net operating profit at production stage',
+    subtitle: 'Total net operating profit per stage',
+    getValue: (studyData) => getNetOperatingProfitPerProducer(studyData, false),
+    getSubValues: (studyData) => getNetOperatingProfitForOtherStages(studyData, false),
+    format: 'amount'
+  },
+  {
     title: 'Net operating profit per producer',
     subtitle: 'Average net operating profit per actor at each stage',
-    getValue: getNetOperatingProfitPerProducer,
-    getSubValues: getNetOperatingProfitForOtherStages,
+    getValue: (studyData) => getNetOperatingProfitPerProducer(studyData, true),
+    getSubValues: (studyData) => getNetOperatingProfitForOtherStages(studyData, true),
     format: 'amount'
   },
   {
@@ -77,15 +84,17 @@ function getJobsByStage(studyData) {
   return jobsByStage
 }
 
-function getNetOperatingProfitPerProducer(studyData) {
+function getNetOperatingProfitPerProducer(studyData, perActor = false) {
   if (!studyData.metrics.eco?.netOperatingProfit) {
     return null
   }
 
-  return studyData.metrics.eco.netOperatingProfit?.Producers?.profitPerActor
+  return studyData.metrics.eco.netOperatingProfit?.Producers?.[
+    perActor ? 'profitPerActor' : 'totalProfit'
+  ]
 }
 
-function getNetOperatingProfitForOtherStages(studyData) {
+function getNetOperatingProfitForOtherStages(studyData, perActor = false) {
   if (!studyData.metrics.eco?.netOperatingProfit) {
     return {}
   }
@@ -96,7 +105,9 @@ function getNetOperatingProfitForOtherStages(studyData) {
   )
   nonProducerStages.forEach((stageName) => {
     netOperatingProfitForOtherStages[buildPerStageName(stageName)] =
-      studyData.metrics.eco.netOperatingProfit?.[stageName]?.profitPerActor
+      studyData.metrics.eco.netOperatingProfit?.[stageName]?.[
+        perActor ? 'profitPerActor' : 'totalProfit'
+      ]
   })
   return netOperatingProfitForOtherStages
 }

--- a/src/components/comparison/comparisonConfig/economics.js
+++ b/src/components/comparison/comparisonConfig/economics.js
@@ -3,6 +3,12 @@ import _ from 'lodash'
 
 export const economicsConfig = [
   {
+    title: 'Value added',
+    subtitle: 'Total value added of value chain',
+    getValue: getTotalAddedValue,
+    format: 'amount'
+  },
+  {
     title: 'Share of national GDP',
     subtitle: 'Value chain GDP divided by national GDP',
     getValue: (study) => study.ecoData?.macroData?.valueAddedShareNationalGdp,
@@ -13,12 +19,6 @@ export const economicsConfig = [
     subtitle: 'Value chain GDP divided by agricultural GDP',
     getValue: (study) => study.ecoData?.macroData?.valueAddedShareAgriculturalGdp,
     format: 'percent'
-  },
-  {
-    title: 'Value added',
-    subtitle: 'Total value added of value chain',
-    getValue: getTotalAddedValue,
-    format: 'amount'
   },
   {
     title: 'Rate of Integration',

--- a/src/components/study/inclusiveness/NetOperatingProfit.vue
+++ b/src/components/study/inclusiveness/NetOperatingProfit.vue
@@ -11,7 +11,11 @@
           :options="netOperatingProfitData"
           @chart-series-click="handleDataChartSeriesClick"
         />
-        <MiniChartContainer v-if="selectedStage" :currentStage="selectedStage" title="Net Operating Profit">
+        <MiniChartContainer
+          v-if="selectedStage"
+          :currentStage="selectedStage"
+          title="Net Operating Profit"
+        >
           <div class="flex flex-row w-full justify-evenly mt-6">
             <div class="w-full flex flex-row justify-center">
               <Ring
@@ -29,10 +33,7 @@
 <script setup>
 import { computed, ref } from 'vue'
 import BarChart from '@charts/BarChart.vue'
-import { 
-    getNetOperatingProfitData,
-    getNetOperatingProfitByTypeOfActorData
-} from '@/charts/charts'
+import { getNetOperatingProfitData, getNetOperatingProfitByTypeOfActorData } from '@/charts/charts'
 import Ring from '@charts/Ring.vue'
 import InfoTitle from '@typography/InfoTitle.vue'
 import { useCurrencyUtils } from '@utils/format.js'
@@ -40,28 +41,33 @@ import { useActorsAndStages } from '@utils/misc.js'
 import MiniChartContainer from '@charts/MiniChartContainer.vue'
 
 const props = defineProps({
-    studyData: Object,
-    currency: String
+  studyData: Object,
+  currency: String
 })
 
 const selectedStage = ref(null)
 const handleDataChartSeriesClick = (event) => {
   if (selectedStage.value == event.name) {
     selectedStage.value = null
-  }
-  else {
+  } else {
     selectedStage.value = event.name
   }
 }
 
-const { prettyAmount, convertAmount } = useCurrencyUtils(props);
-const { stages, actors } = useActorsAndStages(props);
+const { prettyAmount, convertAmount } = useCurrencyUtils(props)
+const { stages, actors } = useActorsAndStages(props)
 
-const netOperatingProfitData = computed(() => getNetOperatingProfitData(stages, actors, convertAmount, prettyAmount, selectedStage))
+const netOperatingProfitData = computed(() =>
+  getNetOperatingProfitData(stages, actors, convertAmount, prettyAmount, selectedStage)
+)
 
 const currentStageNetOperatingProfitByTypeOfActorData = computed(() => {
-    const currentStageActors = actors.value.filter(actor => actor.stage === selectedStage.value)
-    return getNetOperatingProfitByTypeOfActorData(currentStageActors, convertAmount.value, prettyAmount.value)
+  const currentStageActors = actors.value.filter((actor) => actor.stage === selectedStage.value)
+  return getNetOperatingProfitByTypeOfActorData(
+    currentStageActors,
+    convertAmount.value,
+    prettyAmount.value
+  )
 })
 </script>
 

--- a/src/components/study/inclusiveness/NetOperatingProfitPerActor.vue
+++ b/src/components/study/inclusiveness/NetOperatingProfitPerActor.vue
@@ -56,13 +56,13 @@ const { prettyAmount, convertAmount } = useCurrencyUtils(props)
 const { actors } = useActorsAndStages(props)
 
 const netOperatingProfitByNumberActorsData = computed(() => {
-  if (!props.studyData.metrics.eco.netOperatingProfitPerActor) {
+  if (!props.studyData.metrics.eco.netOperatingProfit) {
     return
   }
 
   let tooltip = {}
 
-  const items = Object.entries(props.studyData.metrics.eco.netOperatingProfitPerActor).map(
+  const items = Object.entries(props.studyData.metrics.eco.netOperatingProfit).map(
     ([stageName, { profitPerActor, stageActors }]) => {
       let toolTipValue = ''
       for (const actor of stageActors) {

--- a/src/components/study/inclusiveness/NetOperatingProfitPerActor.vue
+++ b/src/components/study/inclusiveness/NetOperatingProfitPerActor.vue
@@ -56,24 +56,34 @@ const { prettyAmount, convertAmount } = useCurrencyUtils(props)
 const { actors } = useActorsAndStages(props)
 
 const netOperatingProfitByNumberActorsData = computed(() => {
-  if (! props.studyData.metrics.eco.netOperatingProfitPerActor) { return; }
+  if (!props.studyData.metrics.eco.netOperatingProfitPerActor) {
+    return
+  }
 
   let tooltip = {}
 
-  const items = Object.entries(props.studyData.metrics.eco.netOperatingProfitPerActor).map(([stageName, { profitPerActor, stageActors }]) => {
-    let toolTipValue = ""
-    for (const actor of stageActors) {
+  const items = Object.entries(props.studyData.metrics.eco.netOperatingProfitPerActor).map(
+    ([stageName, { profitPerActor, stageActors }]) => {
+      let toolTipValue = ''
+      for (const actor of stageActors) {
         toolTipValue += `${actor.name}: net operating profit= ${prettyAmount.value(convertAmount.value(actor.netOperatingProfit))} -- #actors= ${formatNumber(actor.numberOfActors)}<br>`
-    }
-    tooltip[stageName] = toolTipValue
-    return {
+      }
+      tooltip[stageName] = toolTipValue
+      return {
         name: stageName,
         value: convertAmount.value(profitPerActor)
+      }
     }
-  });
+  )
 
-  return getSelectableBarChart(items, selectedStage.value, tooltip, prettyAmount.value, selectedStage);
-});
+  return getSelectableBarChart(
+    items,
+    selectedStage.value,
+    tooltip,
+    prettyAmount.value,
+    selectedStage
+  )
+})
 
 const currentStageSplitData = computed(() => {
   const currentStageActors = actors.value.filter((actor) => actor.stage === selectedStage.value)

--- a/src/utils/data/metrics/eco/netOperatingProfit.js
+++ b/src/utils/data/metrics/eco/netOperatingProfit.js
@@ -1,13 +1,13 @@
 import _ from 'lodash'
 
-export function buildNetOperatingProfitPerActor(ecoData) {
+export function buildNetOperatingProfit(ecoData) {
   const actors = ecoData.actors
   if (!actors) {
     return null
   }
   const stages = _.uniq(actors.map((actor) => actor.stage))
 
-  const netOperatingProfitPerActorByStage = {}
+  const netOperatingProfitByStage = {}
 
   stages.forEach((stageName) => {
     const stageActors = actors.filter((actor) => actor.stage === stageName)
@@ -20,12 +20,13 @@ export function buildNetOperatingProfitPerActor(ecoData) {
     }))
 
     if (subTotalOperatingProfit !== 0 && subTotalNumberOfActors !== 0) {
-      netOperatingProfitPerActorByStage[stageName] = {
+      netOperatingProfitByStage[stageName] = {
+        totalProfit: subTotalOperatingProfit,
         profitPerActor: subTotalOperatingProfit / subTotalNumberOfActors,
         stageActors: partialStageActors
       }
     }
   })
 
-  return netOperatingProfitPerActorByStage
+  return netOperatingProfitByStage
 }

--- a/src/utils/data/metrics/eco/netOperatingProfitPerActor.js
+++ b/src/utils/data/metrics/eco/netOperatingProfitPerActor.js
@@ -1,21 +1,23 @@
-import _ from "lodash";
+import _ from 'lodash'
 
 export function buildNetOperatingProfitPerActor(ecoData) {
-  const actors = ecoData.actors;
-  if (! actors) { return null; }
-  const stages = _.uniq(actors.map(actor => actor.stage));
+  const actors = ecoData.actors
+  if (!actors) {
+    return null
+  }
+  const stages = _.uniq(actors.map((actor) => actor.stage))
 
-  const netOperatingProfitPerActorByStage = {};
+  const netOperatingProfitPerActorByStage = {}
 
-  stages.forEach(stageName => {
-    const stageActors = actors.filter(actor => actor.stage === stageName)
-    const subTotalOperatingProfit = _.sumBy(stageActors, actor => actor.netOperatingProfit || 0);
-    const subTotalNumberOfActors = _.sumBy(stageActors, actor => actor.numberOfActors || 0);
-    const partialStageActors = stageActors.map(actor => ({
+  stages.forEach((stageName) => {
+    const stageActors = actors.filter((actor) => actor.stage === stageName)
+    const subTotalOperatingProfit = _.sumBy(stageActors, (actor) => actor.netOperatingProfit || 0)
+    const subTotalNumberOfActors = _.sumBy(stageActors, (actor) => actor.numberOfActors || 0)
+    const partialStageActors = stageActors.map((actor) => ({
       name: actor.name,
       netOperatingProfit: actor.netOperatingProfit,
-      numberOfActors: actor.numberOfActors,
-    }));
+      numberOfActors: actor.numberOfActors
+    }))
 
     if (subTotalOperatingProfit !== 0 && subTotalNumberOfActors !== 0) {
       netOperatingProfitPerActorByStage[stageName] = {
@@ -23,7 +25,7 @@ export function buildNetOperatingProfitPerActor(ecoData) {
         stageActors: partialStageActors
       }
     }
-  });
+  })
 
-  return netOperatingProfitPerActorByStage;
+  return netOperatingProfitPerActorByStage
 }

--- a/src/utils/data/metrics/index.js
+++ b/src/utils/data/metrics/index.js
@@ -1,6 +1,6 @@
-import { buildBenefitCostRatioData } from "./eco/benefitCostRatio.js";
-import { buildGlobalEmploymentData } from "./eco/employment.js";
-import { buildNetOperatingProfitPerActor } from "./eco/netOperatingProfitPerActor.js";
+import { buildBenefitCostRatioData } from './eco/benefitCostRatio.js'
+import { buildGlobalEmploymentData } from './eco/employment.js'
+import { buildNetOperatingProfitPerActor } from './eco/netOperatingProfitPerActor.js'
 
 export function computeMetrics(studyData) {
   return {
@@ -9,11 +9,13 @@ export function computeMetrics(studyData) {
 }
 
 function buildEcoMetrics(studyData) {
-  if (! studyData.ecoData) { return null; }
+  if (!studyData.ecoData) {
+    return null
+  }
 
   return {
     benefitCostRatio: buildBenefitCostRatioData(studyData.ecoData),
     employment: buildGlobalEmploymentData(studyData.ecoData),
     netOperatingProfitPerActor: buildNetOperatingProfitPerActor(studyData.ecoData)
-  };
+  }
 }

--- a/src/utils/data/metrics/index.js
+++ b/src/utils/data/metrics/index.js
@@ -1,6 +1,6 @@
 import { buildBenefitCostRatioData } from './eco/benefitCostRatio.js'
 import { buildGlobalEmploymentData } from './eco/employment.js'
-import { buildNetOperatingProfitPerActor } from './eco/netOperatingProfitPerActor.js'
+import { buildNetOperatingProfit } from './eco/netOperatingProfit.js'
 
 export function computeMetrics(studyData) {
   return {
@@ -16,6 +16,6 @@ function buildEcoMetrics(studyData) {
   return {
     benefitCostRatio: buildBenefitCostRatioData(studyData.ecoData),
     employment: buildGlobalEmploymentData(studyData.ecoData),
-    netOperatingProfitPerActor: buildNetOperatingProfitPerActor(studyData.ecoData)
+    netOperatingProfit: buildNetOperatingProfit(studyData.ecoData)
   }
 }


### PR DESCRIPTION
https://www.notion.so/le-basic/Modif-indicateurs-co-Page-de-comparaison-13c6afc9ad6480958ca2f7a29e0ca9d9

## Contexte

Frédéric veut qu'on ajoute un rang avec le net operating profit

## Changements

- Ajout du profit total des actors dans les métriques (et utilisation dans la page inclusivness)
- Utilisation de cette nouvelle clé dans les métriques pour ajouter le row
- EDIT: Déplacement de la ligne de value added (comme demandé en bonus dans la tache notion)
