### PR TITLE
Feat: Refactor Social sustainability page design

### DIFF
--- a/src/components/study/social-sustainability/SocialDetails.vue
+++ b/src/components/study/social-sustainability/SocialDetails.vue
@@ -1,15 +1,22 @@
 <template>
   <div v-for="(part, index) in studyData.socialData" :key="part.title">
-    <h2 :id="`social_anchor_${index + 1}`" class="text-xl text-[#151515] relative">
-      <InfoTitle :title="part.title" :information="getTooltipText(part.title)" />
-    </h2>
+    <div :id="`social_anchor_${index + 1}`" class="details-header">
+      <div class="details-title">
+        <div class="title">{{ part.title }}</div>
+
+        <Tag class="group-tag" :scale="getSocialAverageGroup(part)" v-tooltip="'Aggregated note'" />
+      </div>
+      <div>{{ getTooltipText(part.title) }}</div>
+    </div>
     <SocialDetailsGroup v-for="group in part.groups" :key="group.title" :group="group" />
   </div>
 </template>
 
 <script setup>
+import { vTooltip } from 'floating-vue'
+import Tag from './Tag.vue'
 import SocialDetailsGroup from './SocialDetailsGroup.vue'
-import InfoTitle from '@typography/InfoTitle.vue'
+import { getSocialAverageGroup } from '@utils/social.js'
 
 defineProps({
   studyData: Object
@@ -49,12 +56,36 @@ function getTooltipText(partName) {
 </script>
 
 <style scoped lang="scss">
-h2::before {
-  content: '';
-  width: 90%;
-  height: 1.2rem;
-  border-bottom: solid 4px #151515;
-  position: absolute;
-  bottom: 0;
+.details-header {
+  position: relative;
+  padding-bottom: 10px;
+
+  .details-title {
+    display: flex;
+    gap: 15px;
+    align-items: end;
+    margin-bottom: 10px;
+
+    .title {
+      font-size: 1.25rem !important;
+      line-height: 1.75rem !important;
+      font-weight: 600;
+      color: #151515;
+    }
+  }
+
+  .group-tag {
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+
+  &::before {
+    content: '';
+    width: 100%;
+    height: 1.2rem;
+    border-bottom: solid 4px #151515;
+    position: absolute;
+    bottom: 0;
+  }
 }
 </style>

--- a/src/components/study/social-sustainability/SocialRadar.vue
+++ b/src/components/study/social-sustainability/SocialRadar.vue
@@ -1,5 +1,5 @@
 <template>
-  <Radar :options="chartData" />
+  <Radar class="radar" :options="chartData" />
 </template>
 
 <script setup>
@@ -18,6 +18,14 @@ const averageFood = computed(() => getSocialAverageGroup(props.studyData.socialD
 const averageSocial = computed(() => getSocialAverageGroup(props.studyData.socialData[4]))
 const averageLiving = computed(() => getSocialAverageGroup(props.studyData.socialData[5]))
 
+const indicators = [
+  'Working conditions',
+  'Living\nconditions',
+  'Social\ncapital',
+  'Food & nutrition security',
+  'Gender\nequality',
+  'Land &\nwater\nrights'
+]
 const chartData = computed(() => {
   const values = [
     averageWorking.value,
@@ -30,16 +38,9 @@ const chartData = computed(() => {
 
   return {
     radar: {
-      indicator: [
-        { name: 'Working conditions', max: 4 },
-        { name: 'Living conditions', max: 4 },
-        { name: 'Social capital', max: 4 },
-        { name: 'Food & nutrition security', max: 4 },
-        { name: 'Gender equality', max: 4 },
-        { name: 'Land & water rights', max: 4 }
-      ],
+      indicator: indicators.map((indicatorTitle) => ({ name: indicatorTitle, max: 4 })),
       center: ['50%', '50%'],
-      radius: '100%',
+      radius: '80%',
       splitNumber: 4,
       splitArea: {
         areaStyle: {
@@ -60,26 +61,12 @@ const chartData = computed(() => {
         show: false
       },
       axisName: {
-        show: false,
-        formatter: function (value) {
-          return value
-        },
-        fontWeight: 'bold',
-        fontSize: '18px'
+        show: true,
+        color: 'black'
       }
     },
     tooltip: {
-      show: false,
-      trigger: 'item',
-      formatter: function () {
-        return `Working: ${averageWorking.value}<br />
-                Living: ${averageLiving.value}<br />
-                Social: ${averageSocial.value}<br />
-                Food: ${averageFood.value}<br />
-                Gender: ${averageGender.value}<br />
-                Land: ${averageLand.value}<br />
-                `
-      }
+      show: false
     },
     series: [
       {
@@ -92,7 +79,10 @@ const chartData = computed(() => {
         },
         data: [
           {
-            value: values
+            value: values,
+            label: {
+              show: false
+            }
           }
         ]
       }
@@ -101,4 +91,8 @@ const chartData = computed(() => {
 })
 </script>
 
-<style lang=""></style>
+<style scoped lang="scss">
+.radar {
+  width: 430px;
+}
+</style>

--- a/src/components/study/social-sustainability/SocialSummary.vue
+++ b/src/components/study/social-sustainability/SocialSummary.vue
@@ -30,8 +30,8 @@
       <b class="highlight" :style="{ backgroundColor: getSocialScoreColor(1) }">not at all (red)</b
       >.
     </p>
-    <div class="mt-4 grid grid-cols-3 w-full gap-2">
-      <div class="row-span-2 self-start xl:self-end">
+    <div class="social-summary">
+      <div class="summary-block side-block block-top">
         <SummaryBlock
           title="Living conditions"
           :anchor="6"
@@ -41,7 +41,7 @@
           <SummaryBlockQuestion :question="questionLivingEducation" />
         </SummaryBlock>
       </div>
-      <div>
+      <div class="summary-block block-top">
         <SummaryBlock
           title="Working conditions"
           :anchor="1"
@@ -51,7 +51,7 @@
           <SummaryBlockQuestion :question="workingConditionsHighlightQuestion2" />
         </SummaryBlock>
       </div>
-      <div class="row-span-2 self-start xl:self-end">
+      <div class="summary-block side-block block-top">
         <SummaryBlock
           title="Land &amp; water rights"
           :anchor="2"
@@ -61,12 +61,10 @@
           <SummaryBlockQuestion :question="questionParticipation" />
         </SummaryBlock>
       </div>
-      <div class="row-span-2">
-        <div class="w-full h-[400px]">
-          <SocialRadar :studyData="studyData" />
-        </div>
+      <div class="radar-block w-full h-[400px]">
+        <SocialRadar :studyData="studyData" />
       </div>
-      <div class="row-span-2 self-end xl:self-start">
+      <div class="summary-block side-block block-bottom">
         <SummaryBlock
           title="Social capital"
           :anchor="5"
@@ -76,7 +74,7 @@
           <SummaryBlockQuestion :question="questionFarmerInformation" />
         </SummaryBlock>
       </div>
-      <div class="row-span-2 self-end xl:self-start">
+      <div class="summary-block side-block block-bottom">
         <SummaryBlock
           title="Gender equality"
           :anchor="3"
@@ -86,7 +84,7 @@
           <SummaryBlockQuestion :question="questionWomenIncome" />
         </SummaryBlock>
       </div>
-      <div class="">
+      <div class="summary-block block-bottom">
         <SummaryBlock
           title="Food &amp; nutrition security"
           :anchor="4"
@@ -141,5 +139,44 @@ const questionLivingEducation = computed(() => props.studyData.socialData[5].gro
 <style lang="scss" scoped>
 .highlight {
   padding: 1px 3px;
+}
+
+.social-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5em;
+  width: 100%;
+  margin-top: 1rem;
+
+  .radar-block {
+    height: 400px;
+    width: 100%;
+    grid-row: span 2 / span 2;
+    display: flex;
+    justify-content: center;
+  }
+  .summary-block {
+    display: flex;
+    justify-content: center;
+    height: fit-content;
+  }
+  .side-block {
+    grid-row: span 2 / span 2;
+  }
+  .block-top {
+    align-self: end;
+  }
+  .block-bottom {
+    align-self: start;
+  }
+
+  @media screen and (max-width: 1600px) {
+    .side-block {
+      grid-row: span 1 / span 1;
+    }
+    .radar-block {
+      grid-column: span 3 / span 3;
+    }
+  }
 }
 </style>

--- a/src/components/study/social-sustainability/SocialSummary.vue
+++ b/src/components/study/social-sustainability/SocialSummary.vue
@@ -19,12 +19,13 @@
     </p>
     <p>
       The four levels of social sustainability are illustrated by different colours in the chart:
-      <b class="highlight" :style="{ backgroundColor: getSocialScoreColor(4) }">high (green)</b>,
+      <b class="highlight" :style="{ backgroundColor: getSocialScoreColor(4) }">high (dark green)</b
+      >,
       <b class="highlight" :style="{ backgroundColor: getSocialScoreColor(3) }"
-        >substantial (yellow)</b
+        >substantial (light green)</b
       >,
       <b class="highlight" :style="{ backgroundColor: getSocialScoreColor(2) }"
-        >moderate/low (orange)</b
+        >moderate/low (yellow)</b
       >,
       <b class="highlight" :style="{ backgroundColor: getSocialScoreColor(1) }">not at all (red)</b
       >.

--- a/src/components/study/social-sustainability/SummaryBlock.vue
+++ b/src/components/study/social-sustainability/SummaryBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="rounded-lg p-4 max-w-[500px]" :style="bgColor">
+  <div class="rounded-lg p-4 max-w-[100%]" :style="bgColor">
     <div class="uppercase font-bold">
       {{ title }}
     </div>

--- a/src/components/study/social-sustainability/SummaryBlock.vue
+++ b/src/components/study/social-sustainability/SummaryBlock.vue
@@ -1,12 +1,15 @@
 <template>
   <div class="rounded-lg p-4 max-w-[100%]" :style="bgColor">
-    <div class="uppercase font-bold">
-      {{ title }}
+    <div class="header">
+      <div class="uppercase font-bold">{{ title }}</div>
+      <Tag :scale="parseFloat(averageValue)" />
     </div>
+    <div class="font-bold mb-1">Selected questions:</div>
+
     <slot />
     <div class="browsable-radar-chart__item__more-info">
       <a class="cursor-pointer font-bold text-[#2e6bad]" @click="slideTo(anchorLink)"
-        >Explore {{ title.toLowerCase() }} &rarr;</a
+        >Explore all questions &rarr;</a
       >
     </div>
   </div>
@@ -15,6 +18,7 @@
 <script setup>
 import { computed } from 'vue'
 import { getSocialScoreColor } from '@utils/social.js'
+import Tag from './Tag.vue'
 const props = defineProps({
   title: String,
   anchor: Number,
@@ -39,4 +43,12 @@ const bgColor = computed(() => {
 })
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.header {
+  display: flex;
+  gap: 5px;
+  align-items: baseline;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+</style>


### PR DESCRIPTION
## Contexte

La page sociale des études ne rends pas bien en petit écran, et il manque quelques informations pour bien la comprendre

- Rendre la grille avec les sommaires plus responsive, et ajouter les titres des axes afin de bien comprendre les correspondances
- Mise à jour des blocs de sommaires pour clarifier que les questions sont une sélection parmi plusieurs
- Changement du style des titres sur le détail pour bien comprendre que c'est un titre 